### PR TITLE
Allow logging to multiple output

### DIFF
--- a/examples/cmd/testapp/cmd/log.go
+++ b/examples/cmd/testapp/cmd/log.go
@@ -3,6 +3,8 @@ package cmd
 // Copyright (C) 2021 by RStudio, PBC.
 
 import (
+	"log"
+
 	"github.com/rstudio/platform-lib/pkg/logger"
 	"github.com/spf13/cobra"
 )
@@ -12,13 +14,21 @@ var (
 )
 
 func init() {
-	logger.SetDefaultLogger(logger.NewLoggerImpl(logger.LoggerOptionsImpl{
-		Enabled:  true,
-		Output:   "STDOUT",
-		Format:   "JSON",
-		Level:    "INFO",
-		Filepath: "",
-	}, logger.NewOutputLogBuilder(logger.ServerLog)))
+	lgr, err := logger.NewLoggerImpl(logger.LoggerOptionsImpl{
+		Output: []logger.OutputDest{
+			{
+				Output: logger.LogOutputStdout,
+			},
+		},
+		Format: logger.JSONFormat,
+		Level:  logger.DebugLevel,
+	}, logger.NewOutputLogBuilder(logger.ServerLog, ""))
+
+	if err != nil {
+		log.Fatalf("%w", err)
+	}
+
+	logger.SetDefaultLogger(lgr)
 	LogCmd.Example = `  rspm log --message=hello
 `
 	LogCmd.Flags().StringVar(&message, "message", "default message", "The message to log.")

--- a/pkg/logger/discard_logger.go
+++ b/pkg/logger/discard_logger.go
@@ -34,10 +34,10 @@ func (l discardLogger) Copy() Logger {
 	return l
 }
 
-func (discardLogger) SetLevel(level LogLevel)       {}
-func (discardLogger) SetOutput(output io.Writer)    {}
-func (discardLogger) OnConfigReload(level LogLevel) {}
-func (discardLogger) SetReportCaller(flag bool)     {}
+func (discardLogger) SetLevel(level LogLevel)        {}
+func (discardLogger) SetOutput(writers ...io.Writer) {}
+func (discardLogger) OnConfigReload(level LogLevel)  {}
+func (discardLogger) SetReportCaller(flag bool)      {}
 
 var DiscardLogger discardLogger = discardLogger{}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -17,7 +17,7 @@ type Logger interface {
 	Fatalf(msg string, args ...interface{})
 	Fatal(args ...interface{})
 
-	SetOutput(output io.Writer)
+	SetOutput(writers ...io.Writer)
 	Copy() Logger
 	WithField(key string, value interface{}) Logger
 	WithFields(fields Fields) Logger

--- a/pkg/logger/logger_impl.go
+++ b/pkg/logger/logger_impl.go
@@ -111,7 +111,8 @@ func (l LoggerImpl) SetLevel(level LogLevel) {
 	l.Logger.SetLevel(logrusLevel)
 }
 
-func (l LoggerImpl) SetOutput(output io.Writer) {
+func (l LoggerImpl) SetOutput(writers ...io.Writer) {
+	output := io.MultiWriter(writers...)
 	l.Logger.SetOutput(output)
 }
 
@@ -147,8 +148,9 @@ func (l logrusEntryWrapper) SetLevel(level LogLevel) {
 	l.Entry.Logger.SetLevel(getLevel(level))
 }
 
-func (l logrusEntryWrapper) SetOutput(w io.Writer) {
-	l.Entry.Logger.SetOutput(w)
+func (l logrusEntryWrapper) SetOutput(writers ...io.Writer) {
+	output := io.MultiWriter(writers...)
+	l.Entry.Logger.SetOutput(output)
 }
 
 func (l logrusEntryWrapper) WithField(key string, value interface{}) Logger {

--- a/pkg/logger/logger_impl.go
+++ b/pkg/logger/logger_impl.go
@@ -15,38 +15,57 @@ const (
 func init() {
 	// Set a default logger on init. This is mainly to prevent test failures since
 	// the default logger would otherwise be unset.
-	defaultLogger = NewLoggerImpl(LoggerOptionsImpl{
-		Enabled: false,
-		Output:  "STDOUT",
-		Format:  "TEXT",
-		Level:   "DEBUG",
-	}, NewOutputLogBuilder(ServerLog))
+	defaultLogger, _ = NewLoggerImpl(LoggerOptionsImpl{
+		Output: []OutputDest{
+			{
+				LogOutputStdout,
+				"",
+				"",
+			},
+		},
+		Format: TextFormat,
+		Level:  InfoLevel,
+	}, NewOutputLogBuilder(ServerLog, ""))
 }
 
 type LoggerImpl struct {
 	*logrus.Logger
 }
 
+type OutputDest struct {
+	Output      LogOutputType
+	Filepath    string
+	DefaultFile string
+}
+
 type LoggerOptionsImpl struct {
-	Enabled  bool
-	Output   LogOutputType
-	Format   OutputFormat
-	Level    LogLevel
-	Filepath string
+	Output []OutputDest
+	Level  LogLevel
+	Format OutputFormat
 }
 
 func NewLoggerImpl(options LoggerOptionsImpl,
 	outputBuilder OutputBuilder,
-) *LoggerImpl {
+) (*LoggerImpl, error) {
+	var output []io.Writer
 
 	l := logrus.New()
-	l.SetOutput(outputBuilder.Build(options.Output, options.Filepath, options.Filepath))
+
+	for _, out := range options.Output {
+		wrtr, err := outputBuilder.Build(out.Output, out.Filepath)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, wrtr)
+	}
+
+	l.SetOutput(io.MultiWriter(output...))
 	l.SetFormatter(getFormatter(options.Format))
 	l.SetLevel(getLevel(options.Level))
 
 	return &LoggerImpl{
 		Logger: l,
-	}
+	}, nil
 }
 
 func DefaultLogger() Logger {

--- a/pkg/logger/loggertest/mocks.go
+++ b/pkg/logger/loggertest/mocks.go
@@ -14,9 +14,9 @@ type OutputBuilderMock struct {
 	mock.Mock
 }
 
-func (m *OutputBuilderMock) Build(output logger.LogOutputType, logFilePath, defaultLogFilePath string) io.Writer {
-	args := m.Called(output, logFilePath, defaultLogFilePath)
-	return args.Get(0).(io.Writer)
+func (m *OutputBuilderMock) Build(output logger.LogOutputType, logFilePath string) (io.Writer, error) {
+	args := m.Called(output, logFilePath)
+	return args.Get(0).(io.Writer), args.Error(1)
 }
 
 type IoWriterMock struct {

--- a/pkg/logger/loggertest/mocks.go
+++ b/pkg/logger/loggertest/mocks.go
@@ -117,8 +117,8 @@ func (m *LoggerMock) SetLevel(level logger.LogLevel) {
 	m.Called(level)
 }
 
-func (m *LoggerMock) SetOutput(output io.Writer) {
-	m.Called(output)
+func (m *LoggerMock) SetOutput(writers ...io.Writer) {
+	m.Called(writers)
 }
 
 func (m *LoggerMock) OnConfigReload(level logger.LogLevel) {


### PR DESCRIPTION
Connected to #19 

- Allow logging to multiple output
- Remove the responsibility to create default log files from this lib (products should handle that)