### PR TITLE
Debug logging extras

### DIFF
--- a/examples/cmd/testapp/cmd/log.go
+++ b/examples/cmd/testapp/cmd/log.go
@@ -25,7 +25,7 @@ func init() {
 	}, logger.NewOutputLogBuilder(logger.ServerLog, ""))
 
 	if err != nil {
-		log.Fatalf("%w", err)
+		log.Fatalf("%v", err)
 	}
 
 	logger.SetDefaultLogger(lgr)

--- a/pkg/logger/capturing_logger.go
+++ b/pkg/logger/capturing_logger.go
@@ -2,7 +2,10 @@ package logger
 
 // Copyright (C) 2021 by RStudio, PBC.
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
 // CapturingLogger is a direct logger that remembers _all_ its logged
 // messages. Useful for tests.
@@ -42,4 +45,48 @@ func (logger *CaptureOnlyLogger) Output(msg string) {
 
 func (logger *CaptureOnlyLogger) Reset() {
 	logger.Messages = nil
+}
+
+func (logger *CaptureOnlyLogger) Debugf(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, msg)
+}
+
+func (logger *CaptureOnlyLogger) Infof(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, msg)
+}
+
+func (logger *CaptureOnlyLogger) Warnf(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, msg)
+}
+
+func (logger *CaptureOnlyLogger) Errorf(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, msg)
+}
+
+func (logger *CaptureOnlyLogger) Fatalf(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, msg)
+}
+
+func (logger *CaptureOnlyLogger) Fatal(args ...interface{}) {
+}
+
+func (logger *CaptureOnlyLogger) WithField(key string, value interface{}) Logger {
+	return logger
+}
+
+func (logger *CaptureOnlyLogger) WithFields(fields Fields) Logger {
+	return logger
+}
+
+func (logger *CaptureOnlyLogger) SetLevel(_ LogLevel) {
+}
+
+func (logger *CaptureOnlyLogger) SetReportCaller(bool) {
+}
+
+func (logger *CaptureOnlyLogger) Copy() Logger {
+	return logger
+}
+
+func (logger *CaptureOnlyLogger) SetOutput(writers ...io.Writer) {
 }

--- a/pkg/logger/debug/debug.go
+++ b/pkg/logger/debug/debug.go
@@ -110,13 +110,12 @@ type DebugLogger interface {
 
 type debugLogger struct {
 	logger.Logger
-	lgr    logger.Logger
 	region ProductRegion
 }
 
 // NewDebugLogger returns a new logger which includes
 // the name of the debug region at every message.
-func NewDebugLogger(region ProductRegion, lgrIn logger.Logger) DebugLogger {
+func NewDebugLogger(region ProductRegion, lgrIn logger.Logger) *debugLogger {
 	lgr := lgrIn.Copy()
 
 	if Enabled(region) {
@@ -130,7 +129,6 @@ func NewDebugLogger(region ProductRegion, lgrIn logger.Logger) DebugLogger {
 
 	dbglgr := &debugLogger{
 		Logger: entry,
-		lgr:    entry,
 		region: region,
 	}
 
@@ -150,10 +148,9 @@ func (l *debugLogger) Enabled() bool {
 
 // Set fields to be logged
 func (l *debugLogger) WithFields(fields logger.Fields) DebugLogger {
-	newLgr := l.lgr.WithFields(fields)
+	newLgr := l.Logger.WithFields(fields)
 	dbglgr := &debugLogger{
 		Logger: newLgr,
-		lgr:    newLgr,
 		region: l.region,
 	}
 	registerLoggerCb(l.region, dbglgr.enable)
@@ -163,10 +160,9 @@ func (l *debugLogger) WithFields(fields logger.Fields) DebugLogger {
 // WithSubRegion returns a debug logger with further specificity
 // via sub_region key:value. E.g "region": "LDAP", "sub_region": "membership scanner"
 func (l *debugLogger) WithSubRegion(subregion string) DebugLogger {
-	newLgr := l.lgr.WithField("sub_region", subregion)
+	newLgr := l.Logger.WithField("sub_region", subregion)
 	dbglgr := &debugLogger{
 		Logger: newLgr,
-		lgr:    newLgr,
 		region: l.region,
 	}
 	registerLoggerCb(l.region, dbglgr.enable)
@@ -176,9 +172,9 @@ func (l *debugLogger) WithSubRegion(subregion string) DebugLogger {
 // Enable or disable this region debug logging instance
 func (l *debugLogger) enable(enabled bool) {
 	if enabled {
-		l.lgr.SetLevel(logger.DebugLevel)
+		l.Logger.SetLevel(logger.DebugLevel)
 	} else {
-		l.lgr.SetLevel(logger.ErrorLevel)
+		l.Logger.SetLevel(logger.ErrorLevel)
 	}
-	l.lgr.SetReportCaller(enabled)
+	l.Logger.SetReportCaller(enabled)
 }

--- a/pkg/logger/debug/debug_test.go
+++ b/pkg/logger/debug/debug_test.go
@@ -12,12 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// type DebugLoggerSuite struct {
-// 	suite.Suite
-
-// 	loggerMock *loggertest.LoggerMock
-// }
-
 const (
 	Nothing = debug.ProductRegion(iota)
 	Proxy

--- a/pkg/logger/debug/debug_test.go
+++ b/pkg/logger/debug/debug_test.go
@@ -1,4 +1,4 @@
-package debug
+package debug_test
 
 // Copyright (C) 2021 by RStudio, PBC.
 
@@ -6,19 +6,20 @@ import (
 	"testing"
 
 	"github.com/rstudio/platform-lib/pkg/logger"
+	"github.com/rstudio/platform-lib/pkg/logger/debug"
 	"github.com/rstudio/platform-lib/pkg/logger/loggertest"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
 
-type DebugLoggerSuite struct {
-	suite.Suite
+// type DebugLoggerSuite struct {
+// 	suite.Suite
 
-	loggerMock *loggertest.LoggerMock
-}
+// 	loggerMock *loggertest.LoggerMock
+// }
 
 const (
-	Nothing = ProductRegion(iota)
+	Nothing = debug.ProductRegion(iota)
 	Proxy
 	RProc
 	Router
@@ -28,7 +29,13 @@ const (
 )
 
 func init() {
-	RegisterRegions(map[ProductRegion]string{})
+	debug.RegisterRegions(map[debug.ProductRegion]string{})
+}
+
+type DebugLoggerSuite struct {
+	suite.Suite
+
+	loggerMock *loggertest.LoggerMock
 }
 
 func TestDebugLoggerSuite(t *testing.T) {
@@ -36,95 +43,69 @@ func TestDebugLoggerSuite(t *testing.T) {
 }
 
 func (s *DebugLoggerSuite) TestInitLog() {
-	// Nothing is enabled with an empty set.
-	InitLogs(nil)
-	s.Len(regionsEnabled, 0)
-
-	// Nothing is enabled with bogus input
-	InitLogs([]ProductRegion{Nothing})
-	s.Len(regionsEnabled, 0)
+	s.False(debug.Enabled(Proxy))
 
 	// Singular region enabled.
-	InitLogs([]ProductRegion{Proxy})
-	s.Equal(regionsEnabled, map[ProductRegion]bool{Proxy: true})
+	debug.InitLogs([]debug.ProductRegion{Proxy})
+	s.True(debug.Enabled(Proxy))
 
 	// multiple regions enabled (using translation and normalization)
-	InitLogs([]ProductRegion{Proxy, RProc, Router})
-	s.Equal(regionsEnabled,
-		map[ProductRegion]bool{
-			Proxy:  true,
-			RProc:  true,
-			Router: true,
-		})
+	debug.InitLogs([]debug.ProductRegion{
+		Proxy,
+		RProc,
+		Router,
+	})
+	s.True(debug.Enabled(Proxy))
+	s.True(debug.Enabled(RProc))
+	s.True(debug.Enabled(Router))
 
 	// calling InitLogs resets what is enabled.
-	InitLogs(nil)
-	s.Len(regionsEnabled, 0)
+	debug.InitLogs(nil)
+	s.False(debug.Enabled(Proxy))
+	s.False(debug.Enabled(RProc))
+	s.False(debug.Enabled(Router))
 }
 
 func (s *DebugLoggerSuite) TestNewDebugLogger() {
-	s.Len(regionCallbacks, 0)
-
-	lgr := NewDebugLogger(Proxy, logger.DiscardLogger)
+	lgr := debug.NewDebugLogger(Proxy, logger.DiscardLogger)
 	s.Equal(lgr.Enabled(), false)
-	s.Len(regionCallbacks, 1)
-	s.Len(regionCallbacks[Proxy], 1)
 
-	Enable(Proxy)
+	debug.Enable(Proxy)
 	s.Equal(lgr.Enabled(), true)
 
 	// Logger with fields should be under same region, new callback
 	fieldslgr := lgr.WithFields(logger.Fields{"id": "654-987"})
 	s.Equal(fieldslgr.Enabled(), true)
-	s.Len(regionCallbacks, 1)
-	s.Len(regionCallbacks[Proxy], 2)
 
 	// SubRegion Logger should be under same region, new callback
 	sublgr := lgr.WithSubRegion("balancer")
 	s.Equal(sublgr.Enabled(), true)
-	s.Len(regionCallbacks, 1)
-	s.Len(regionCallbacks[Proxy], 3)
 
 	// For a totally different region
-	another := NewDebugLogger(LDAP, logger.DiscardLogger)
+	another := debug.NewDebugLogger(LDAP, logger.DiscardLogger)
 	s.Equal(another.Enabled(), false)
-	s.Len(regionCallbacks, 2)
-	s.Len(regionCallbacks[LDAP], 1)
-	s.Len(regionCallbacks[Proxy], 3)
 }
 
 func (s *DebugLoggerSuite) TestUpdateToLevelAndCaller() {
 	base := &loggertest.LoggerMock{}
-	lgr := &debugLogger{
-		Logger: base,
-		lgr:    base,
-		region: OAuth2,
-	}
-
-	registerLoggerCb(OAuth2, lgr.enable)
-	s.Equal(Enabled(OAuth2), false)
+	lgr := debug.NewDebugLogger(OAuth2, logger.DiscardLogger)
+	lgr.Logger = base
 
 	base.On("SetLevel", logger.DebugLevel)
 	base.On("SetReportCaller", true)
-	Enable(OAuth2)
-	s.Equal(Enabled(OAuth2), true)
+	debug.Enable(OAuth2)
+	s.True(debug.Enabled(OAuth2))
 	base.AssertExpectations(s.T())
 
 	// Sub loggers
 	baseTwo := &loggertest.LoggerMock{}
-	lgr = &debugLogger{
-		Logger: baseTwo,
-		lgr:    baseTwo,
-		region: Session,
-	}
-
-	registerLoggerCb(Session, lgr.enable)
-	s.Equal(Enabled(Session), false)
+	lgr = debug.NewDebugLogger(Session, logger.DiscardLogger)
+	lgr.Logger = baseTwo
 
 	baseTwo.On("SetLevel", logger.DebugLevel)
 	baseTwo.On("SetReportCaller", true)
-	Enable(Session)
-	s.Equal(Enabled(Session), true)
+	debug.Enable(Session)
+	s.True(debug.Enabled(Session))
 	baseTwo.AssertExpectations(s.T())
 
 	baseTwo.On("WithFields", mock.Anything).Return(baseTwo)
@@ -132,8 +113,8 @@ func (s *DebugLoggerSuite) TestUpdateToLevelAndCaller() {
 
 	baseTwo.On("SetLevel", logger.ErrorLevel)
 	baseTwo.On("SetReportCaller", false)
-	Disable(Session)
-	s.Equal(Enabled(Session), false)
+	debug.Disable(Session)
+	s.False(debug.Enabled(Session))
 
 	// Should have called level AND report caller (2 calls)
 	// Should have called with fields for sub logger (3 calls)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -24,7 +24,7 @@ type Logger interface {
 	SetLevel(level LogLevel)
 	SetReportCaller(bool)
 
-	// TODO: remove this interface when the Connect migration process to the new logging standard is complete.
+	// TODO: remove this interface when the migration process to the new logging standard is complete.
 	// It is being added just to help migrate packages that inject the Logger interface inside another packages.
 	DeprecatedLogger
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -23,6 +23,10 @@ type Logger interface {
 	WithFields(fields Fields) Logger
 	SetLevel(level LogLevel)
 	SetReportCaller(bool)
+
+	// TODO: remove this interface when the Connect migration process to the new logging standard is complete.
+	// It is being added just to help migrate packages that inject the Logger interface inside another packages.
+	DeprecatedLogger
 }
 
 type Fields map[string]interface{}

--- a/pkg/logger/logger_impl.go
+++ b/pkg/logger/logger_impl.go
@@ -144,6 +144,11 @@ func (l LoggerImpl) OnConfigReload(level LogLevel) {
 	}
 }
 
+// TODO: remove this function when the Connect migration process to the new logging standard is complete.
+func (l LoggerImpl) Logf(msg string, args ...interface{}) {
+	l.Infof(msg, args...)
+}
+
 func (l LoggerImpl) SetReportCaller(flag bool) {
 	l.Logger.SetReportCaller(flag)
 }
@@ -184,6 +189,11 @@ func (l logrusEntryWrapper) WithFields(fields Fields) Logger {
 
 func (l logrusEntryWrapper) SetReportCaller(flag bool) {
 	l.Logger.SetReportCaller(flag)
+}
+
+// TODO: remove this function when the Connect migration process to the new logging standard is complete.
+func (l logrusEntryWrapper) Logf(msg string, args ...interface{}) {
+	l.Infof(msg, args...)
 }
 
 var defaultLogger Logger

--- a/pkg/logger/logger_impl.go
+++ b/pkg/logger/logger_impl.go
@@ -144,7 +144,7 @@ func (l LoggerImpl) OnConfigReload(level LogLevel) {
 	}
 }
 
-// TODO: remove this function when the Connect migration process to the new logging standard is complete.
+// TODO: remove this function when the migration process to the new logging standard is complete.
 func (l LoggerImpl) Logf(msg string, args ...interface{}) {
 	l.Infof(msg, args...)
 }
@@ -191,7 +191,7 @@ func (l logrusEntryWrapper) SetReportCaller(flag bool) {
 	l.Logger.SetReportCaller(flag)
 }
 
-// TODO: remove this function when the Connect migration process to the new logging standard is complete.
+// TODO: remove this function when the migration process to the new logging standard is complete.
 func (l logrusEntryWrapper) Logf(msg string, args ...interface{}) {
 	l.Infof(msg, args...)
 }

--- a/pkg/logger/loggertest/mocks.go
+++ b/pkg/logger/loggertest/mocks.go
@@ -5,8 +5,11 @@ package loggertest
 import (
 	"fmt"
 	"io"
+	"log"
+	"regexp"
 
 	"github.com/rstudio/platform-lib/pkg/logger"
+	"github.com/rstudio/platform-lib/pkg/logger/debug"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -57,6 +60,31 @@ func (m *LoggerMock) Call(index int) string {
 func (m *LoggerMock) LastCall() string {
 	calls := m.stringCalls
 	return calls[len(calls)-1]
+}
+
+// Determine if provided messages match with calls with no particular order
+func (m *LoggerMock) MessagesMatch(matchRgx []string) bool {
+	for _, rgx := range matchRgx {
+		entryResult := false
+		rxObj, err := regexp.Compile("^" + rgx + "$")
+		if err != nil {
+			log.Output(2, fmt.Sprintf("LoggerMock.MessagesMatch: Could not compile regex: %s", rgx))
+			return false
+		}
+
+		for i := range m.Calls {
+			msg := m.Call(i)
+			if entryResult = rxObj.MatchString(msg); entryResult {
+				break
+			}
+		}
+
+		if !entryResult {
+			log.Output(2, fmt.Sprintf("%s did not match any message", rgx))
+			return false
+		}
+	}
+	return true
 }
 
 func (m *LoggerMock) Debugf(msg string, args ...interface{}) {
@@ -138,7 +166,12 @@ func (m *DebugLoggerMock) Enabled() bool {
 	return args.Get(0).(bool)
 }
 
-func (m *DebugLoggerMock) WithSubRegion(subregion string) *DebugLoggerMock {
+func (m *DebugLoggerMock) WithFields(fields logger.Fields) debug.DebugLogger {
+	args := m.Called(fields)
+	return args.Get(0).(debug.DebugLogger)
+}
+
+func (m *DebugLoggerMock) WithSubRegion(subregion string) debug.DebugLogger {
 	args := m.Called(subregion)
-	return args.Get(0).(*DebugLoggerMock)
+	return args.Get(0).(debug.DebugLogger)
 }

--- a/pkg/logger/loggertest/mocks.go
+++ b/pkg/logger/loggertest/mocks.go
@@ -121,6 +121,12 @@ func (m *LoggerMock) Fatalf(msg string, args ...interface{}) {
 	m.Called(msg, args)
 }
 
+// TODO: remove this function when the Connect migration process to the new logging standard is complete.
+func (m *LoggerMock) Logf(msg string, args ...interface{}) {
+	m.stringCalls = append(m.stringCalls, fmt.Sprintf(msg, args...))
+	m.Called(msg, args)
+}
+
 func (m *LoggerMock) WithField(key string, value interface{}) logger.Logger {
 	args := m.Called(key, value)
 	return args.Get(0).(logger.Logger)


### PR DESCRIPTION
- Use default logger within output builder (to use the latest configured logger whenever possible)
- Fixed DefaultLoggerMock (missing method), and return interfaces on methods for flexibility