### PR TITLE
Adds Panicf function to Logger interface

### DIFF
--- a/pkg/logger/capturing_logger.go
+++ b/pkg/logger/capturing_logger.go
@@ -48,26 +48,31 @@ func (logger *CaptureOnlyLogger) Reset() {
 }
 
 func (logger *CaptureOnlyLogger) Debugf(msg string, args ...interface{}) {
-	logger.Messages = append(logger.Messages, msg)
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) Infof(msg string, args ...interface{}) {
-	logger.Messages = append(logger.Messages, msg)
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) Warnf(msg string, args ...interface{}) {
-	logger.Messages = append(logger.Messages, msg)
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) Errorf(msg string, args ...interface{}) {
-	logger.Messages = append(logger.Messages, msg)
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) Fatalf(msg string, args ...interface{}) {
-	logger.Messages = append(logger.Messages, msg)
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) Fatal(args ...interface{}) {
+	logger.Messages = append(logger.Messages, fmt.Sprint(args...))
+}
+
+func (logger *CaptureOnlyLogger) Panicf(msg string, args ...interface{}) {
+	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
 func (logger *CaptureOnlyLogger) WithField(key string, value interface{}) Logger {

--- a/pkg/logger/discard_logger.go
+++ b/pkg/logger/discard_logger.go
@@ -14,6 +14,7 @@ func (discardLogger) Warnf(msg string, args ...interface{})  {}
 func (discardLogger) Errorf(msg string, args ...interface{}) {}
 func (discardLogger) Fatalf(msg string, args ...interface{}) {}
 func (discardLogger) Fatal(args ...interface{})              {}
+func (discardLogger) Panicf(msg string, v ...interface{})    {}
 
 // Doing nothing with the provided values. Just to implement the interface and be able to switch to old logging implementation
 func (l discardLogger) WithField(key string, value interface{}) Logger {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -16,6 +16,7 @@ type Logger interface {
 	Errorf(msg string, args ...interface{})
 	Fatalf(msg string, args ...interface{})
 	Fatal(args ...interface{})
+	Panicf(msg string, args ...interface{})
 
 	SetOutput(writers ...io.Writer)
 	Copy() Logger

--- a/pkg/logger/logger_impl.go
+++ b/pkg/logger/logger_impl.go
@@ -226,6 +226,10 @@ func Fatalf(msg string, args ...interface{}) {
 	defaultLogger.Fatalf(msg, args...)
 }
 
+func Panicf(msg string, args ...interface{}) {
+	defaultLogger.Panicf(msg, args...)
+}
+
 func WithField(key string, value interface{}) Logger {
 	return defaultLogger.WithField(key, value)
 }

--- a/pkg/logger/loggertest/mocks.go
+++ b/pkg/logger/loggertest/mocks.go
@@ -127,6 +127,11 @@ func (m *LoggerMock) Logf(msg string, args ...interface{}) {
 	m.Called(msg, args)
 }
 
+func (m *LoggerMock) Panicf(msg string, args ...interface{}) {
+	m.stringCalls = append(m.stringCalls, fmt.Sprintf(msg, args...))
+	m.Called(msg, args)
+}
+
 func (m *LoggerMock) WithField(key string, value interface{}) logger.Logger {
 	args := m.Called(key, value)
 	return args.Get(0).(logger.Logger)


### PR DESCRIPTION
Adding `Panicf` function to the Logger interface.
This function was added in a commit when the logger package was inside Connect. 

