### PR TITLE
Add IP() to interface; postgres -> pgx

### DIFF
--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -18,7 +18,6 @@ import (
 	"log"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/pglistener"
 )
 
 type Matcher func(notification listener.Notification) bool
@@ -62,10 +61,7 @@ func (b *NotificationBroadcaster) IP() string {
 	if b.listener == nil {
 		return ""
 	}
-	if l, ok := b.listener.(*pglistener.PostgresListener); ok {
-		return l.IP()
-	}
-	return ""
+	return b.listener.IP()
 }
 
 func (b *NotificationBroadcaster) broadcast() {

--- a/pkg/rsnotify/broadcaster/broadcaster_test.go
+++ b/pkg/rsnotify/broadcaster/broadcaster_test.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/pglistener"
+	"github.com/rstudio/platform-lib/pkg/rsnotify/pgxlistener"
 )
 
 type BroadcasterSuite struct{}
@@ -44,6 +44,10 @@ func (f *FakeListener) Listen() (items chan listener.Notification, errs chan err
 func (f *FakeListener) Stop() {
 	close(f.items)
 	close(f.errs)
+}
+
+func (f *FakeListener) IP() string {
+	return ""
 }
 
 func (s *BroadcasterSuite) TestNewNotificationBroadcaster(c *check.C) {
@@ -218,6 +222,6 @@ func (s *BroadcasterSuite) TestBroadcasterIP(c *check.C) {
 	b.listener = &FakeListener{}
 	c.Assert(b.IP(), check.Equals, "")
 
-	b.listener = pglistener.NewPostgresListenerWithIP("192.168.1.11")
+	b.listener = pgxlistener.NewPgxListenerWithIP("192.168.1.11")
 	c.Assert(b.IP(), check.Equals, "192.168.1.11")
 }

--- a/pkg/rsnotify/factory/listenerfactory_test.go
+++ b/pkg/rsnotify/factory/listenerfactory_test.go
@@ -52,8 +52,8 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 		},
 	})
 	lgr := &listener.TestLogger{}
-	l2 := NewPostgresListenerFactory(pool, lgr)
-	c.Check(l2, check.DeepEquals, &PostgresListenerFactory{
+	l2 := NewPgxListenerFactory(pool, lgr)
+	c.Check(l2, check.DeepEquals, &PgxListenerFactory{
 		pool:        pool,
 		debugLogger: lgr,
 		commonListenerFactory: commonListenerFactory{

--- a/pkg/rsnotify/listener/listener.go
+++ b/pkg/rsnotify/listener/listener.go
@@ -52,6 +52,7 @@ type Notification interface {
 type Listener interface {
 	Listen() (items chan Notification, errs chan error, err error)
 	Stop()
+	IP() string
 }
 
 type Logger interface {

--- a/pkg/rsnotify/locallistener/locallistener.go
+++ b/pkg/rsnotify/locallistener/locallistener.go
@@ -73,6 +73,10 @@ func (l *LocalListenerFactory) New(name string) *LocalListener {
 var ErrNotInFactory = errors.New("a local listener must be created with the LocalListenerFactory.New method")
 var ErrNotNotificationType = errors.New("a notification must be of type listener.Notification")
 
+func (l *LocalListener) IP() string {
+	return ""
+}
+
 func (l *LocalListener) Listen() (chan listener.Notification, chan error, error) {
 	if l.factory == nil {
 		return nil, nil, ErrNotInFactory

--- a/pkg/rsnotify/pgxlistener/pgxlistener_test.go
+++ b/pkg/rsnotify/pgxlistener/pgxlistener_test.go
@@ -1,6 +1,6 @@
-package pglistener
+package pgxlistener
 
-/* pglistener_test.go
+/* pgxlistener_test.go
  *
  * Copyright (C) 2021 by RStudio, PBC
  * All Rights Reserved.
@@ -25,37 +25,37 @@ import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
 )
 
-type NotifySuite struct {
+type PgxNotifySuite struct {
 	pool *pgxpool.Pool
 }
 
-var _ = check.Suite(&NotifySuite{})
+var _ = check.Suite(&PgxNotifySuite{})
 
 func TestPackage(t *testing.T) { check.TestingT(t) }
 
-func (s *NotifySuite) SetUpSuite(c *check.C) {
+func (s *PgxNotifySuite) SetUpSuite(c *check.C) {
 	if testing.Short() {
-		c.Skip("skipping postgres notification tests because -short was provided")
+		c.Skip("skipping pgx notification tests because -short was provided")
 	}
 
 	var err error
-	s.pool, err = EphemeralPostgresPool("postgres")
+	s.pool, err = EphemeralPgxPool("postgres")
 	c.Assert(err, check.IsNil)
 }
 
-func (s *NotifySuite) TearDownSuite(c *check.C) {
+func (s *PgxNotifySuite) TearDownSuite(c *check.C) {
 	if testing.Short() {
-		c.Skip("skipping postgres notification tests because -short was provided")
+		c.Skip("skipping pgx notification tests because -short was provided")
 	}
 
 	s.pool.Close()
 }
 
-func (s *NotifySuite) TestNewPostgresListener(c *check.C) {
+func (s *PgxNotifySuite) TestNewPgxListener(c *check.C) {
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
 	lgr := &listener.TestLogger{}
-	l := NewPostgresListener("test-a", &testNotification{}, s.pool, unmarshallers, lgr)
-	c.Check(l, check.DeepEquals, &PostgresListener{
+	l := NewPgxListener("test-a", &testNotification{}, s.pool, unmarshallers, lgr)
+	c.Check(l, check.DeepEquals, &PgxListener{
 		name:          "test-a",
 		pool:          s.pool,
 		t:             &testNotification{},
@@ -69,12 +69,12 @@ type testNotification struct {
 	Val string
 }
 
-func (s *NotifySuite) notify(channel string, n *testNotification, c *check.C) {
+func (s *PgxNotifySuite) notify(channel string, n *testNotification, c *check.C) {
 	err := Notify(channel, n, s.pool)
 	c.Assert(err, check.IsNil)
 }
 
-func (s *NotifySuite) TestNotificationsNormal(c *check.C) {
+func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 	defer leaktest.Check(c)()
 
 	tn := testNotification{
@@ -83,7 +83,7 @@ func (s *NotifySuite) TestNotificationsNormal(c *check.C) {
 
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
 
-	l := NewPostgresListener("test-a", &tn, s.pool, unmarshallers, nil)
+	l := NewPgxListener("test-a", &tn, s.pool, unmarshallers, nil)
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -162,7 +162,7 @@ func (s *NotifySuite) TestNotificationsNormal(c *check.C) {
 	l.Stop()
 }
 
-func (s *NotifySuite) TestNotificationsBlock(c *check.C) {
+func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 	defer leaktest.Check(c)()
 
 	tn := testNotification{
@@ -171,7 +171,7 @@ func (s *NotifySuite) TestNotificationsBlock(c *check.C) {
 
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
 
-	l := NewPostgresListener("test-a", &tn, s.pool, unmarshallers, nil)
+	l := NewPgxListener("test-a", &tn, s.pool, unmarshallers, nil)
 
 	// Listen for notifications
 	data, errs, err := l.Listen()

--- a/pkg/rsnotify/pgxlistener/pgxlistenertest.go
+++ b/pkg/rsnotify/pgxlistener/pgxlistenertest.go
@@ -1,6 +1,6 @@
-package pglistener
+package pgxlistener
 
-/* pglistenertest.go
+/* pgxlistenertest.go
  *
  * Copyright (C) 2021 by RStudio, PBC
  * All Rights Reserved.
@@ -14,8 +14,8 @@ package pglistener
  * prior written permission is obtained.
  */
 
-func NewPostgresListenerWithIP(ip string) *PostgresListener {
-	return &PostgresListener{
+func NewPgxListenerWithIP(ip string) *PgxListener {
+	return &PgxListener{
 		ip: ip,
 	}
 }

--- a/pkg/rsnotify/pgxlistener/pgxtest.go
+++ b/pkg/rsnotify/pgxlistener/pgxtest.go
@@ -1,6 +1,6 @@
-package pglistener
+package pgxlistener
 
-/* pgtest.go
+/* pgxtest.go
  *
  * Copyright (C) 2021 by RStudio, PBC
  * All Rights Reserved.
@@ -22,7 +22,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
-func EphemeralPostgresPool(dbname string) (pool *pgxpool.Pool, err error) {
+func EphemeralPgxPool(dbname string) (pool *pgxpool.Pool, err error) {
 	connectionString := fmt.Sprintf("postgres://admin:password@postgres/%s?sslmode=disable", dbname)
 	config, err := pgxpool.ParseConfig(connectionString)
 	if err != nil {


### PR DESCRIPTION
* Adds `IP() string` to the listener interface.
* Renames `Postgres` references  to `Pgx` to be consistent with our `jackc/pgx` implementation.