### PR TITLE
Add unit tests to CI; test Postgres with docker-compose

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,7 +1,0 @@
-# build/action.yml
-name: 'Build Platform-Lib'
-description: 'Builds the project'
-runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  entrypoint: '/build.sh'

--- a/.github/actions/build/build.sh
+++ b/.github/actions/build/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-just build

--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -4,16 +4,25 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: extractions/setup-just@v1
+
+      - name: Image
+        run: just build-build-env
+
       - name: Build
-        uses: ./.github/actions/build
+        run: just build-docker
+
+      - name: Test
+        run: just test-integration
+
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v2
         with:
           name: testapp
           path: out/testapp
           retention-days: 5
+
       - name: 'Test Artifact'
         uses: ./.github/actions/test
         with:

--- a/README.md
+++ b/README.md
@@ -47,16 +47,22 @@ Examples:
 just test
 
 # Run all Go tests twice
-just test "-count 2"
+just test -count 2 ./...
 
 # Run all tests once (no cached results)
-just test "-count 1"
+just test -count 1 ./...
 
 # Run with verbose output
-just test "-v"
+just test -v ./...
 
 # Run the "TestNewDebugLog" test twice with verbose output
-just test "-count 2 -testify.m TestNewDebugLog -v"
+just test -v -count 2 github.com/rstudio/platform-lib/pkg/rslog/debug -testify.m=TestNewDebugLog
+
+# Run the LocalNotifySuite suite tests with verbose output
+just test -v github.com/rstudio/platform-lib/pkg/rsnotify/locallistener -check.f=LocalNotifySuite
+
+# Run the PgxNotifySuite suite tests with docker-compose
+just test-integration -v github.com/rstudio/platform-lib/pkg/rsnotify/pgxlistener -check.f=PgxNotifySuite
 
 # Run the end-to-end tests
 just build

--- a/docker/bionic/Dockerfile
+++ b/docker/bionic/Dockerfile
@@ -75,7 +75,3 @@ RUN GO111MODULE=on PATH="$PATH:/usr/local/go/bin" GOPATH=/usr/local/gotools GOBI
     github.com/go-delve/delve/cmd/dlv@master && \
     mv /tmp/dlv $GOPATH/bin/dlv-dap
 ENV PATH="$PATH:/usr/local/gotools/bin:/usr/local/go/bin"
-
-# Copy build script
-COPY build.sh /build.sh
-RUN chmod 755 /build.sh

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,33 @@
+version: '2.1'
+
+services:
+  lib:
+    image: rstudio/platform-lib:lib-build
+    build:
+      context: bionic
+      dockerfile: Dockerfile
+    links:
+      - postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    privileged: true
+    volumes:
+      - ..:/platform-lib
+    environment:
+      GO111MODULE: auto
+    working_dir: /platform-lib
+
+  postgres:
+    image: postgres:9.6
+    ports:
+      - "5432"
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: test
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/justfile
+++ b/justfile
@@ -8,9 +8,40 @@ HOME_DIR := env_var_or_default('HOST_HOME', env_var('HOME'))
 
 HOSTNAME := env_var_or_default('HOSTNAME', '')
 
+# are we attached to a terminal?
+interactive := `tty -s && echo "-it" || echo ""`
+
 # Runs Go unit tests
-test args='':
-    go test ./... {{args}}
+test *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    test_args="{{ args }}"
+    test_args=${test_args:-./...}
+    go test -short ${test_args[*]}
+
+# Runs Go unit tests with docker-compose
+test-integration *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # When run in GitHub Actions, the following is set to 1
+    export AD_CI=${AD_CI:-0}
+
+    # use a randomized project name to allow simultaneous test runs
+    project="platform-lib-it-$(openssl rand -hex 4)"
+    dc="docker-compose -f docker/docker-compose.test.yml -p ${project}"
+
+    function cleanup() {
+        ${dc} logs --no-color > test-integration-${project}.log
+        ${dc} down -v --remove-orphans
+    }
+    trap cleanup EXIT
+
+    test_args="{{ args }}"
+    test_args=${test_args:-./...}
+    ${dc} run lib \
+        go test -v ${test_args[*]}
 
 # Checks Go code
 vet:
@@ -23,7 +54,7 @@ build:
 # Builds Go code using docker. Useful when using a MacOS or Windows native IDE. First,
 # run `just build-build-env' to create the docker image you'll need.
 build-docker:
-    docker run -it --rm \
+    docker run {{ interactive }} --rm \
         -v {{justfile_directory()}}/:/build \
         -w /build \
         rstudio/platform-lib:lib-build go build -o out/ ./...
@@ -34,7 +65,7 @@ clean:
 
 # Builds the docker image used for building Go code
 build-build-env:
-    docker build -t rstudio/platform-lib:lib-build -f .github/actions/build/Dockerfile .github/actions/build
+    docker build -t rstudio/platform-lib:lib-build -f docker/bionic/Dockerfile docker/bionic
 
 # Builds the docker image for e2e testing
 build-e2e-env:

--- a/pkg/rslog/debug/debug_test.go
+++ b/pkg/rslog/debug/debug_test.go
@@ -62,6 +62,7 @@ func (s *DebugLoggerSuite) TestInitLog() {
 
 func (s *DebugLoggerSuite) TestNewDebugLogger() {
 	lgr := debug.NewDebugLogger(Proxy, rslog.DiscardLogger)
+	defer debug.Disable(Proxy)
 	s.Equal(lgr.Enabled(), false)
 
 	debug.Enable(Proxy)


### PR DESCRIPTION
* GHA simplifications.
* Adds unit tests to CI.
* Adds `test-integration` target to `justfile`. Updates README accordingly.
* Adds docker-compose configuration for testing against PostgreSQL.