### PR TITLE
Add lib/pq listener

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -143,6 +143,46 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
+### github.com/jmoiron/sqlx
+
+```
+Copyright (c) 2013, Jason Moiron
+
+ Permission is hereby granted, free of charge, to any person
+ obtaining a copy of this software and associated documentation
+ files (the "Software"), to deal in the Software without
+ restriction, including without limitation the rights to use,
+ copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following
+ conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### github.com/lib/pq
+
+```
+Copyright (c) 2011-2013, 'pq' Contributors
+Portions Copyright (C) 2011 Blake Mizerany
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
 ### github.com/sirupsen/logrus
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgtype v1.9.1
 	github.com/jackc/pgx/v4 v4.14.1
+	github.com/jmoiron/sqlx v1.3.4
+	github.com/lib/pq v1.10.2
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
@@ -225,6 +227,8 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.2.0 h1:DNDKdn/pDrWvDWyT2FYvpZVE81OAhWrjCv19I9n108Q=
 github.com/jackc/puddle v1.2.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
+github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -254,6 +258,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/rsnotify/factory/listenerfactory_test.go
+++ b/pkg/rsnotify/factory/listenerfactory_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/lib/pq"
 	"gopkg.in/check.v1"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
@@ -25,6 +26,16 @@ import (
 )
 
 type ListenerFactorySuite struct{}
+
+type testFactory struct{}
+
+func (f *testFactory) NewListener() (*pq.Listener, error) {
+	return nil, nil
+}
+
+func (f *testFactory) IP() (string, error) {
+	return "", nil
+}
 
 var _ = check.Suite(&ListenerFactorySuite{})
 
@@ -55,6 +66,15 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	l2 := NewPgxListenerFactory(pool, lgr)
 	c.Check(l2, check.DeepEquals, &PgxListenerFactory{
 		pool:        pool,
+		debugLogger: lgr,
+		commonListenerFactory: commonListenerFactory{
+			unmarshallers: make(map[uint8]listener.Unmarshaller),
+		},
+	})
+	fakeFactory := &testFactory{}
+	l3 := NewPqListenerFactory(fakeFactory, lgr)
+	c.Check(l3, check.DeepEquals, &PqListenerFactory{
+		factory:     fakeFactory,
 		debugLogger: lgr,
 		commonListenerFactory: commonListenerFactory{
 			unmarshallers: make(map[uint8]listener.Unmarshaller),

--- a/pkg/rsnotify/pqlistener/pqlistener.go
+++ b/pkg/rsnotify/pqlistener/pqlistener.go
@@ -1,0 +1,204 @@
+package pqlistener
+
+/* pqlistener.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"time"
+
+	"github.com/lib/pq"
+
+	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
+)
+
+type PqListenerFactory interface {
+	NewListener() (*pq.Listener, error)
+	IP() (string, error)
+}
+
+type PqListener struct {
+	name          string
+	factory       PqListenerFactory
+	conn          *pq.Listener
+	t             listener.Notification
+	cancel        context.CancelFunc
+	exit          chan struct{}
+	unmarshallers map[uint8]listener.Unmarshaller
+	ip            string
+	debugLogger   listener.DebugLogger
+}
+
+// Only intended to be called from listenerfactory.go's `New` method.
+func NewPqListener(name string, i listener.Notification, factory PqListenerFactory, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
+	return &PqListener{
+		name:          name,
+		factory:       factory,
+		t:             i,
+		debugLogger:   debugLogger,
+		unmarshallers: unmarshallers,
+	}
+}
+
+func (l *PqListener) IP() string {
+	return l.ip
+}
+
+func (l *PqListener) Listen() (items chan listener.Notification, errs chan error, err error) {
+	items = make(chan listener.Notification, listener.MaxChannelSize)
+	errs = make(chan error)
+	ready := make(chan struct{})
+
+	go func() {
+		l.exit = make(chan struct{})
+		defer close(l.exit)
+
+		// Create a context that can be cancelled when the server shuts down.
+		ctx, cancel := context.WithCancel(context.Background())
+		l.cancel = cancel
+		defer cancel()
+
+		for {
+			if waitErr := l.wait(ctx, items, errs, ready); err != nil {
+				errs <- waitErr
+			}
+
+			// If we've been signaled to stop, exit. Otherwise, wait a second and retry
+			if needExit(ctx) {
+				return
+			}
+		}
+	}()
+
+	// Ready is notified when we are actively listening. Wait to return until
+	// we have an active listener.
+	<-ready
+	return
+}
+
+func needExit(ctx context.Context) bool {
+	tm := time.NewTimer(time.Second)
+	defer tm.Stop()
+	select {
+	case <-ctx.Done():
+		return true
+	case <-tm.C:
+	}
+	return false
+}
+
+func (l *PqListener) wait(ctx context.Context, items chan listener.Notification, errs chan error, ready chan struct{}) (err error) {
+	// Set up the connection
+	err = l.acquire(ready)
+	if err != nil {
+		return
+	}
+
+	// Listen/Notify event loop
+	ch := l.conn.NotificationChannel()
+	for {
+		select {
+		case n := <-ch:
+			l.notify(n, l.t, errs, items)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (l *PqListener) acquire(ready chan struct{}) (err error) {
+	if l.conn != nil {
+		l.conn.Unlisten(l.name)
+		l.conn.Close()
+		l.conn = nil
+	}
+
+	l.ip = ""
+	l.conn, err = l.factory.NewListener()
+	if err != nil {
+		return fmt.Errorf("error acquiring native connection: %s", err)
+	}
+
+	// Get the connection's IP
+	l.ip, err = l.factory.IP()
+	if err != nil {
+		return
+	}
+
+	err = l.conn.Listen(l.name)
+	if err != nil {
+		return fmt.Errorf("error starting listener: %s", err)
+	}
+
+	// If there were no errors, we are now actively listening. Signal that
+	// we are ready, or log when reconnecting.
+	select {
+	case <-ready:
+		// Already closed. This means that we are reconnecting
+		log.Printf("successfully reconnected listener %s", l.name)
+	default:
+		// Close the `ready` channel to signal that `Listen()` can return.
+		close(ready)
+	}
+
+	return
+}
+
+func (l *PqListener) Debugf(msg string, args ...interface{}) {
+	if l.debugLogger != nil {
+		l.debugLogger.Debugf(msg, args...)
+	}
+}
+
+func (l *PqListener) notify(n *pq.Notification, i interface{}, errs chan error, items chan listener.Notification) {
+	// A notification was received! Unmarshal it into the correct type and send it.
+	var input listener.Notification
+	input = reflect.New(reflect.ValueOf(i).Elem().Type()).Interface().(listener.Notification)
+	payloadBytes := []byte(n.Extra)
+	err := json.Unmarshal(payloadBytes, input)
+	if err != nil {
+		errs <- fmt.Errorf("error unmarshalling JSON: %s", err)
+		return
+	}
+	if unmarshaller, ok := l.unmarshallers[input.Type()]; ok {
+		err = unmarshaller(input, payloadBytes)
+		if err != nil {
+			errs <- fmt.Errorf("error unmarshalling with custom unmarshaller: %s", err)
+			return
+		}
+		l.Debugf("Unmarshalled notification of type %d with registered unmarshaller", input.Type())
+	}
+	items <- input
+}
+
+func (l *PqListener) Stop() {
+	l.Debugf("Signaling context to cancel listener %s", l.name)
+	l.cancel()
+	// Wait for stop
+	l.Debugf("Waiting for listener %s to stop...", l.name)
+	<-l.exit
+
+	// Clean up connection
+	if l.conn != nil {
+		l.conn.Unlisten(l.name)
+		l.conn.Close()
+		l.conn = nil
+	}
+
+	l.Debugf("Listener %s closed.", l.name)
+}

--- a/pkg/rsnotify/pqlistener/pqlistener.go
+++ b/pkg/rsnotify/pqlistener/pqlistener.go
@@ -27,14 +27,14 @@ import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
 )
 
-type PqListenerFactory interface {
+type PqRetrieveListenerFactory interface {
 	NewListener() (*pq.Listener, error)
 	IP() (string, error)
 }
 
 type PqListener struct {
 	name          string
-	factory       PqListenerFactory
+	factory       PqRetrieveListenerFactory
 	conn          *pq.Listener
 	t             listener.Notification
 	cancel        context.CancelFunc
@@ -45,7 +45,7 @@ type PqListener struct {
 }
 
 // Only intended to be called from listenerfactory.go's `New` method.
-func NewPqListener(name string, i listener.Notification, factory PqListenerFactory, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
+func NewPqListener(name string, i listener.Notification, factory PqRetrieveListenerFactory, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
 	return &PqListener{
 		name:          name,
 		factory:       factory,

--- a/pkg/rsnotify/pqlistener/pqlistener_test.go
+++ b/pkg/rsnotify/pqlistener/pqlistener_test.go
@@ -1,0 +1,235 @@
+package pqlistener
+
+/* pqlistener_test.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+import (
+	"log"
+	"testing"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"gopkg.in/check.v1"
+
+	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
+)
+
+type PqNotifySuite struct {
+	factory *testFactory
+	db      *sqlx.DB
+}
+
+type testFactory struct{}
+
+func (f *testFactory) NewListener() (*pq.Listener, error) {
+	return EphemeralPqListener("postgres"), nil
+}
+
+func (f *testFactory) IP() (string, error) {
+	return "", nil
+}
+
+var _ = check.Suite(&PqNotifySuite{})
+
+func TestPackage(t *testing.T) { check.TestingT(t) }
+
+func (s *PqNotifySuite) notify(channel string, n *testNotification, c *check.C) {
+	err := Notify(channel, n, s.db)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *PqNotifySuite) SetUpSuite(c *check.C) {
+	if testing.Short() {
+		c.Skip("skipping pq notification tests because -short was provided")
+	}
+
+	s.factory = &testFactory{}
+
+	var err error
+	s.db, err = EphemeralPqConn("postgres")
+	c.Assert(err, check.IsNil)
+}
+
+func (s *PqNotifySuite) TearDownSuite(c *check.C) {
+	if testing.Short() {
+		c.Skip("skipping pq notification tests because -short was provided")
+	}
+
+	if s.db != nil {
+		s.db.Close()
+	}
+}
+
+func (s *PqNotifySuite) TestNewPqListener(c *check.C) {
+	unmarshallers := make(map[uint8]listener.Unmarshaller)
+	lgr := &listener.TestLogger{}
+	l := NewPqListener("test-a", &testNotification{}, s.factory, unmarshallers, lgr)
+	c.Check(l, check.DeepEquals, &PqListener{
+		name:          "test-a",
+		factory:       s.factory,
+		t:             &testNotification{},
+		unmarshallers: unmarshallers,
+		debugLogger:   lgr,
+	})
+}
+
+type testNotification struct {
+	listener.GenericNotification
+	Val string
+}
+
+func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
+	defer leaktest.Check(c)()
+
+	tn := testNotification{
+		Val: "test-notification",
+	}
+
+	unmarshallers := make(map[uint8]listener.Unmarshaller)
+
+	l := NewPqListener("test-a", &tn, s.factory, unmarshallers, nil)
+
+	// Listen for notifications
+	data, errs, err := l.Listen()
+	c.Assert(err, check.IsNil)
+	done := make(chan struct{})
+	count := 0
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case i := <-data:
+				c.Assert(i.(*testNotification).Val, check.Equals, "test-notification")
+				count++
+				if count == 2 {
+					return
+				}
+			case e := <-errs:
+				log.Printf("error received: %s", e)
+				c.FailNow()
+			}
+		}
+	}()
+
+	// Send some data across the main test channel.
+	s.notify("test-a", &tn, c)
+	// Send some data across a different channel. This should not be seen
+	s.notify("test-b", &testNotification{Val: "different-test"}, c)
+	// Send more data across the main test channel.
+	s.notify("test-a", &tn, c)
+	c.Assert(err, check.IsNil)
+
+	// Wait for test to complete
+	<-done
+
+	// Check IP
+	ip := l.IP()
+	c.Assert(ip, check.Matches, "")
+
+	// Clean up
+	l.Stop()
+	// Can call stop multiple times
+	l.Stop()
+
+	// Attempt more notifications after stopping. These should not be received.
+	s.notify("test-a", &tn, c)
+	c.Assert(err, check.IsNil)
+	s.notify("test-a", &tn, c)
+	c.Assert(err, check.IsNil)
+
+	// Start again, and listen for more notifications
+	data, errs, err = l.Listen()
+	c.Assert(err, check.IsNil)
+	done = make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case i := <-data:
+				c.Assert(i.(*testNotification).Val, check.Equals, "second-test")
+				return
+			case e := <-errs:
+				log.Printf("error received: %s", e)
+				c.FailNow()
+			}
+		}
+	}()
+
+	// This notification should be received.
+	s.notify("test-a", &testNotification{Val: "second-test"}, c)
+	c.Assert(err, check.IsNil)
+
+	// Wait for test to complete
+	<-done
+
+	// Clean up
+	l.Stop()
+}
+
+func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
+	defer leaktest.Check(c)()
+
+	tn := testNotification{
+		Val: "test-notification",
+	}
+
+	unmarshallers := make(map[uint8]listener.Unmarshaller)
+
+	l := NewPqListener("test-a", &tn, s.factory, unmarshallers, nil)
+
+	// Listen for notifications
+	data, errs, err := l.Listen()
+	c.Assert(err, check.IsNil)
+	done := make(chan struct{})
+	count := 0
+	blocker := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Block a while before receiving each message
+		<-blocker
+		log.Printf("Unblocked. Starting to receive.")
+		for {
+			select {
+			case i := <-data:
+				c.Assert(i.(*testNotification).Val, check.Equals, "test-notification")
+				count++
+				if count == 100 {
+					return
+				}
+			case e := <-errs:
+				log.Printf("error received: %s", e)
+				c.FailNow()
+			}
+		}
+	}()
+
+	// Send some data across the main test channel.
+	for i := 0; i < 100; i++ {
+		// Send some data across the main test channel.
+		s.notify("test-a", &tn, c)
+		// Send some data across a different channel. This should not be seen
+		s.notify("test-b", &testNotification{Val: "different-test"}, c)
+	}
+
+	// Block receiving any notifications until all have been sent
+	log.Printf("All messages have been sent")
+	close(blocker)
+
+	// Wait for test to complete
+	<-done
+
+	// Clean up
+	l.Stop()
+}

--- a/pkg/rsnotify/pqlistener/pqlistenertest.go
+++ b/pkg/rsnotify/pqlistener/pqlistenertest.go
@@ -1,0 +1,21 @@
+package pqlistener
+
+/* pqlistenertest.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+func NewPqListenerWithIP(ip string) *PqListener {
+	return &PqListener{
+		ip: ip,
+	}
+}

--- a/pkg/rsnotify/pqlistener/pqtest.go
+++ b/pkg/rsnotify/pqlistener/pqtest.go
@@ -1,0 +1,49 @@
+package pqlistener
+
+/* pqtest.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+)
+
+func EphemeralPqConn(dbname string) (*sqlx.DB, error) {
+	connectionString := fmt.Sprintf("postgres://admin:password@postgres/%s?sslmode=disable", dbname)
+	return sqlx.Connect("postgres", connectionString)
+}
+
+func EphemeralPqListener(dbname string) *pq.Listener {
+	connectionString := fmt.Sprintf("postgres://admin:password@postgres/%s?sslmode=disable", dbname)
+	minReconn := 10 * time.Second
+	maxReconn := time.Minute
+	l := pq.NewListener(connectionString, minReconn, maxReconn, nil)
+	return l
+}
+
+func Notify(channelName string, n interface{}, db *sqlx.DB) error {
+	msgbytes, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+	msg := string(msgbytes)
+	query := fmt.Sprintf(
+		"select pg_notify('%s', $1)", channelName)
+	_, err = db.Exec(query, msg)
+	return err
+}


### PR DESCRIPTION
Adds a beta `lib/pq` listener implementation. So far, this has only been unit tested; we need further testing to prove that it works reliably.