### PR TITLE
Add gofmt and test wiring linting to CI

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -7,6 +7,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1
 
+      - name: Lint
+        run: just lint
+
       - name: Image
         run: just build-build-env
 

--- a/examples/cmd/testapp/cmd/log_test.go
+++ b/examples/cmd/testapp/cmd/log_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+/* log_test.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) { check.TestingT(t) }

--- a/examples/cmd/testapp/main_test.go
+++ b/examples/cmd/testapp/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+/* main_test.go
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ * All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains the property of
+ * RStudio, PBC and its suppliers, if any. The intellectual and technical
+ * concepts contained herein are proprietary to RStudio, PBC and its suppliers
+ * and may be covered by U.S. and Foreign Patents, patents in process, and
+ * are protected by trade secret or copyright law. Dissemination of this
+ * information or reproduction of this material is strictly forbidden unless
+ * prior written permission is obtained.
+ */
+
+import (
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) { check.TestingT(t) }

--- a/justfile
+++ b/justfile
@@ -51,6 +51,11 @@ vet:
 build:
     go build -o out/ ./...
 
+# run linters
+lint:
+    ./scripts/fmt-check.sh
+    ./scripts/test-wiring.sh
+
 # Builds Go code using docker. Useful when using a MacOS or Windows native IDE. First,
 # run `just build-build-env' to create the docker image you'll need.
 build-docker:

--- a/scripts/fmt-check.sh
+++ b/scripts/fmt-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Exit with a non-zero code after checking all packages.
+__EXITCODE=0
+
+for MODULE in "." ; do
+    echo "Checking fmt for module ${MODULE}"
+    if [ ! -f "${MODULE}/go.mod" ] ; then
+        echo "Skipping module ${MODULE}, as it does not contain go.mod."
+        continue
+    fi
+
+    if [ "${MODULE}" = "generate" ] ; then
+        echo "Skipping module ${MODULE}, as its Go files are excluded by build constraints."
+        continue
+    fi
+
+    cd "${MODULE}"
+
+    # Collect a list of go package directories ('go list' skips vendor packages).
+    PACKAGES=$(go list -f '{{.Dir}}' ./...)
+    for pkg in ${PACKAGES}; do
+        # echo "checking package $pkg"
+
+        # If gofmt changes anything, tell the user
+        # shellcheck disable=SC2091
+        # shellcheck disable=SC2034
+        if $(gofmt -d -s "${pkg}"/*.go | read -r SCRATCH); then
+            echo "Go source in package ${pkg} needs formatting"
+            gofmt -d -s "${pkg}"/*.go
+            __EXITCODE=1
+        fi
+    done
+
+    cd ..
+done
+
+exit $__EXITCODE;

--- a/scripts/test-wiring.sh
+++ b/scripts/test-wiring.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+# This script analyizes each go package to ensure that testing is wired up properly
+#   1. gocheck is hooked into testing.T (via `func TestMain(t *testing.T) { check.TestingT(t) }`)
+#   2. Each defined suite is wired into gocheck (via `var _ = check.Suite(&XXXXXXX{})`)
+
+exitcode=0
+
+# find suites that are defined but not enabled
+unplugged_suites() {
+    # Get a list of suite structs defined in this package.
+    #
+    # We ignore suites which begin with lowercase letters; those are not
+    # public and used when defining full suites.
+    defined=$(grep -shE 'type [[:upper:]].*Suite struct' $1/*_test.go | \
+                  awk '{ print $2 }' | \
+                  sort)
+
+    # Get a list of suite structs connected to check.Suite. These lines look
+    # like:
+    #    var _ = check.Suite(&XXXXXXXXX{})
+    #
+    # We ignore NothingSuite because it is used as a placeholder in packages
+    # without test coverage.
+    active_check=$(grep -sh "check.Suite" "$1"/*_test.go | \
+                 awk -F "&" {' print $2 '} | \
+                 awk -F "{" '{ print $1 }' | \
+                 grep -v NothingSuite | \
+                 sort)
+
+    # Get a list of suite structs connected to testify.suite. These lines look
+    # like:
+    #
+    #    suite.Run(t, &CreateEndpointSuite{})
+    active_testify=$(grep -sh "suite.Run" "$1"/*_test.go | \
+                 awk -F "&" {' print $2 '} | \
+                 awk -F "{" '{ print $1 }' | \
+                 sort)
+
+
+    # Suites that are connected multiple times.
+    doubles=$(echo $active_check $active_testify | tr " " "\n" | uniq -d)
+    if [[ "x$doubles" != "x" ]]; then
+        echo "Error: package $1 has test suites connected more than once: ${doubles}"
+        exitcode=1
+    fi
+
+    # Suites that are not connected. Discovered by concatenating defined and
+    # active together and then looking for anything that is NOT repeated.
+    disconnected=$(echo $active_check $active_testify $defined | tr " " "\n" | sort | uniq -u)
+    if [[ "x$disconnected" != "x" ]]; then
+        exitcode=1
+        echo "Error: package $1 has test suites that are disconnected: ${disconnected}"
+    fi
+}
+
+# find packages that don't hook up check to either check.TestingT (for check) or
+# suite.Run (for testify)
+testing_enabled() {
+    count=$(grep -hsc -e "check.TestingT" -e "suite.Run" "$1"/*_test.go | awk '{s+=$1} END {printf "%.0f", s}')
+    if [[ $count == "0" ]]; then
+        echo "Error: package $1 is missing a call to check.TestingT or suite.Run"
+        exitcode=1
+    fi
+}
+
+
+for MODULE in "." ; do
+    echo "Checking test wiring for module ${MODULE}"
+    if [ ! -f "${MODULE}/go.mod" ] ; then
+        echo "Skipping module ${MODULE}, as it does not contain go.mod."
+        continue
+    fi
+
+
+    if [ "${MODULE}" = "generate" ] ; then
+        echo "Skipping module ${MODULE}, as its Go files are excluded by build constraints."
+        continue
+    fi
+
+    cd "${MODULE}"
+
+    # Collect a list of go package directories ('go list' skips vendor packages).
+    PACKAGES=$(go list -f '{{.Dir}}' ./...)
+    for pkg in ${PACKAGES}; do
+        unplugged_suites $pkg
+        testing_enabled $pkg
+    done
+    cd ..
+done
+
+
+exit $exitcode


### PR DESCRIPTION
* Adds `gofmt` format checking.
* Adds test wiring checks.
* Fixes two test-wiring issues.