### PR TITLE
Use correct Go version in CI

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -4,8 +4,15 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: extractions/setup-just@v1
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Checkout code
+        uses: actions/checkout@v2
 
       - name: Lint
         run: just lint


### PR DESCRIPTION
Recently saw a failure due to an undefined `io.Discard`. I'm not sure, but I wonder if the GHA runner was using an outdated Go version. This should ensure that we use the correct Go version.

See https://github.com/rstudio/platform-lib/runs/4855806750?check_suite_focus=true. 