### PR TITLE
Update rsnotify version dependencies

### DIFF
--- a/pkg/rsnotify/listeners/local/go.mod
+++ b/pkg/rsnotify/listeners/local/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/google/uuid v1.1.2
-	github.com/rstudio/platform-lib/pkg/rsnotify v0.1.8
+	github.com/rstudio/platform-lib/pkg/rsnotify v1.0.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )
 

--- a/pkg/rsnotify/listeners/postgrespgx/go.mod
+++ b/pkg/rsnotify/listeners/postgrespgx/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jackc/pgconn v1.10.1
 	github.com/jackc/pgtype v1.9.1
 	github.com/jackc/pgx/v4 v4.14.1
-	github.com/rstudio/platform-lib/pkg/rsnotify v0.1.8
+	github.com/rstudio/platform-lib/pkg/rsnotify v1.0.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )
 

--- a/pkg/rsnotify/listeners/postgrespq/go.mod
+++ b/pkg/rsnotify/listeners/postgrespq/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/jmoiron/sqlx v0.0.0-20170430194603-d9bd385d68c0
 	github.com/lib/pq v1.10.2
-	github.com/rstudio/platform-lib/pkg/rsnotify v0.1.8
+	github.com/rstudio/platform-lib/pkg/rsnotify v1.0.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )
 


### PR DESCRIPTION
Intra-module dependencies should use actual versions.