### PR TITLE
Change CompositeLogger to return a proper value from the Writer function

### DIFF
--- a/pkg/rslog/capturing_logger.go
+++ b/pkg/rslog/capturing_logger.go
@@ -82,7 +82,7 @@ func (logger *DeprecatedCaptureOnlyLogger) Panicf(msg string, args ...interface{
 	logger.Messages = append(logger.Messages, fmt.Sprintf(msg, args...))
 }
 
-func (logger *DeprecatedCaptureOnlyLogger) Writer() *io.PipeWriter {
+func (logger *DeprecatedCaptureOnlyLogger) Writer() io.WriteCloser {
 	return &io.PipeWriter{}
 }
 

--- a/pkg/rslog/discard_logger.go
+++ b/pkg/rslog/discard_logger.go
@@ -18,7 +18,7 @@ func (discardLogger) Fatal(args ...interface{})              {}
 func (discardLogger) Panicf(msg string, v ...interface{})    {}
 
 // Doing nothing with this method. Just to implement the interface and be able to switch to old logging implementation
-func (l discardLogger) Writer() *io.PipeWriter {
+func (l discardLogger) Writer() io.WriteCloser {
 	return &io.PipeWriter{}
 }
 

--- a/pkg/rslog/logger.go
+++ b/pkg/rslog/logger.go
@@ -25,7 +25,7 @@ type Logger interface {
 	SetOutput(writers ...io.Writer)
 	SetLevel(level LogLevel)
 	SetFormatter(formatter OutputFormat)
-	Writer() *io.PipeWriter
+	Writer() io.WriteCloser
 
 	// DeprecatedLogger helps with migrating packages that inject the Logger interface into other packages.
 	// TODO: Remove this interface when the migration process to the new logging standard is complete.

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -102,7 +102,7 @@ func getLevel(level LogLevel) logrus.Level {
 	}
 }
 
-func (l LoggerImpl) Writer() *io.PipeWriter {
+func (l LoggerImpl) Writer() io.WriteCloser {
 	return l.Logger.Writer()
 }
 
@@ -169,6 +169,10 @@ func (l logrusEntryWrapper) WithField(key string, value interface{}) Logger {
 func (l logrusEntryWrapper) WithFields(fields Fields) Logger {
 	e := l.Entry.WithFields(logrus.Fields(fields))
 	return logrusEntryWrapper{Entry: e}
+}
+
+func (l logrusEntryWrapper) Writer() io.WriteCloser {
+	return l.Logger.Writer()
 }
 
 // TODO: remove this function when the migration process to the new logging standard is complete.

--- a/pkg/rslog/rslogtest/composite_logger_test.go
+++ b/pkg/rslog/rslogtest/composite_logger_test.go
@@ -17,7 +17,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 	mock2 := &LoggerMock{}
 	mocks := []*LoggerMock{mock1, mock2}
 
-	logger := rslog.NewCompositeLogger([]rslog.Logger{mock1, mock2})
+	logger := rslog.ComposeLoggers(mock1, mock2)
 
 	// Test common signature log functions
 	testCases := []struct {
@@ -101,7 +101,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 		m.AssertExpectations(s.T())
 	}
 
-	s.EqualValues(newComposite, rslog.NewCompositeLogger([]rslog.Logger{newMock1, newMock2}))
+	s.EqualValues(newComposite, rslog.ComposeLoggers(newMock1, newMock2))
 
 	//Test WithFields function
 
@@ -114,7 +114,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 		m.AssertExpectations(s.T())
 	}
 
-	s.EqualValues(newComposite, rslog.NewCompositeLogger([]rslog.Logger{newMock1, newMock2}))
+	s.EqualValues(newComposite, rslog.ComposeLoggers(newMock1, newMock2))
 
 	// Test SetLevel function
 

--- a/pkg/rslog/rslogtest/mocks.go
+++ b/pkg/rslog/rslogtest/mocks.go
@@ -137,9 +137,9 @@ func (m *LoggerMock) Panicf(msg string, args ...interface{}) {
 	m.Called(msg, args)
 }
 
-func (m *LoggerMock) Writer() *io.PipeWriter {
+func (m *LoggerMock) Writer() io.WriteCloser {
 	args := m.Called()
-	return args.Get(0).(*io.PipeWriter)
+	return args.Get(0).(io.WriteCloser)
 }
 
 func (m *LoggerMock) WithField(key string, value interface{}) rslog.Logger {


### PR DESCRIPTION
I am adding the `CompositeLogger` capability to return multiple writers on the `Writer` function on this PR. 

To make it possible:
- I created a new struct, `multiWriteCloser` (to handle a `WriteCloser` slice as just one `WriteCloser`)
- Changed the return from the `Logger.Writer` function to `io.WriteCloser` (where it will be used, only need this interface).

