### PR TITLE
Creating a discarding logger following the new logging standards

### DIFF
--- a/pkg/rslog/composite_logger.go
+++ b/pkg/rslog/composite_logger.go
@@ -10,7 +10,7 @@ type CompositeLogger struct {
 
 var _ Logger = &CompositeLogger{}
 
-func NewCompositeLogger(loggers []Logger) *CompositeLogger {
+func ComposeLoggers(loggers ...Logger) *CompositeLogger {
 	return &CompositeLogger{
 		loggers: loggers,
 	}

--- a/pkg/rslog/discard_logger.go
+++ b/pkg/rslog/discard_logger.go
@@ -50,3 +50,8 @@ type discardOutputLogger struct {
 	discardLogger
 	discardOutputter
 }
+
+func NewDiscardingLogger() Logger {
+	l, _ := NewLoggerImpl(LoggerOptionsImpl{}, discardOutputBuilder{})
+	return l
+}

--- a/pkg/rslog/rslogtest/composite_logger_test.go
+++ b/pkg/rslog/rslogtest/composite_logger_test.go
@@ -17,7 +17,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 	mock2 := &LoggerMock{}
 	mocks := []*LoggerMock{mock1, mock2}
 
-	logger := rslog.NewCompositeLogger([]rslog.Logger{mock1, mock2})
+	logger := rslog.ComposeLoggers(mock1, mock2)
 
 	// Test common signature log functions
 	testCases := []struct {
@@ -101,7 +101,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 		m.AssertExpectations(s.T())
 	}
 
-	s.EqualValues(newComposite, rslog.NewCompositeLogger([]rslog.Logger{newMock1, newMock2}))
+	s.EqualValues(newComposite, rslog.ComposeLoggers(newMock1, newMock2))
 
 	//Test WithFields function
 
@@ -114,7 +114,7 @@ func (s *LoggerImplTestSuite) TestNewCompositeLogger() {
 		m.AssertExpectations(s.T())
 	}
 
-	s.EqualValues(newComposite, rslog.NewCompositeLogger([]rslog.Logger{newMock1, newMock2}))
+	s.EqualValues(newComposite, rslog.ComposeLoggers(newMock1, newMock2))
 
 	// Test SetLevel function
 

--- a/pkg/rslog/rslogtest/logger_impl_test.go
+++ b/pkg/rslog/rslogtest/logger_impl_test.go
@@ -361,3 +361,11 @@ func (s *LoggerImplTestSuite) TestOnConfigReload() {
 	s.Equal(log.Level, logrus.WarnLevel)
 	s.IsType(&logrus.JSONFormatter{}, log.Formatter)
 }
+
+func (s *LoggerImplTestSuite) TestNewDiscardingLogger() {
+
+	// Ensure that the discarding logger doesn't panic
+	discardingLogger := rslog.NewDiscardingLogger()
+
+	s.NotNil(discardingLogger)
+}


### PR DESCRIPTION
Because some parts of Connect ignore logging, we still need a logger that doesn't log the messages but should implement the logger interface. 

So, this pr aims to:
- Create an easy discarding logger, that implements all functions from the `Logger` interface.
- It also renames the function `NewCompositeLogger` to `ComposeLoggers`.