### PR TITLE
Fix debug child loggers not being enabled

### DIFF
--- a/pkg/rslog/debug.go
+++ b/pkg/rslog/debug.go
@@ -178,8 +178,9 @@ func (l *debugLogger) Tracef(message string, args ...interface{}) {
 func (l *debugLogger) WithFields(fields Fields) DebugLogger {
 	newLgr := l.Logger.WithFields(fields)
 	dbglgr := &debugLogger{
-		Logger: newLgr,
-		region: l.region,
+		Logger:  newLgr,
+		region:  l.region,
+		enabled: l.enabled,
 	}
 	registerLoggerCb(l.region, dbglgr.enable)
 	return dbglgr
@@ -190,8 +191,9 @@ func (l *debugLogger) WithFields(fields Fields) DebugLogger {
 func (l *debugLogger) WithSubRegion(subregion string) DebugLogger {
 	newLgr := l.Logger.WithField("sub_region", subregion)
 	dbglgr := &debugLogger{
-		Logger: newLgr,
-		region: l.region,
+		Logger:  newLgr,
+		region:  l.region,
+		enabled: l.enabled,
 	}
 	registerLoggerCb(l.region, dbglgr.enable)
 	return dbglgr


### PR DESCRIPTION
Debug loggers derived from `WithFields` and `WithSubRegion` weren't respecting the parent `enabled` flag.