### PR TITLE
LoggerMock.Fatal() bug fixes

### DIFF
--- a/pkg/rslog/rslogtest/mocks.go
+++ b/pkg/rslog/rslogtest/mocks.go
@@ -40,7 +40,12 @@ type LoggerMock struct {
 // allowing to be called with any message and arguments
 func (m *LoggerMock) AllowAny(methods ...string) {
 	for _, method := range methods {
-		m.On(method, mock.AnythingOfType("string"), mock.Anything)
+		//todo: I wonder if these should be types rather than string inputs
+		if method == "Fatal" {
+			m.On(method, mock.Anything)
+		} else {
+			m.On(method, mock.AnythingOfType("string"), mock.Anything)
+		}
 	}
 }
 
@@ -117,6 +122,7 @@ func (m *LoggerMock) Errorf(msg string, args ...interface{}) {
 }
 
 func (m *LoggerMock) Fatal(args ...interface{}) {
+	m.stringCalls = append(m.stringCalls, fmt.Sprint(args...))
 	m.Called(args)
 }
 

--- a/pkg/rslog/rslogtest/mocks_test.go
+++ b/pkg/rslog/rslogtest/mocks_test.go
@@ -1,0 +1,75 @@
+package rslogtest
+
+import (
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+func TestPackage(t *testing.T) {
+	suite.Run(t, &MocksSuite{})
+}
+
+type MocksSuite struct {
+	suite.Suite
+}
+
+func (s *MocksSuite) TestLoggerMockCallStack() {
+
+	loggerMock := &LoggerMock{}
+
+	debugfStr := "Debugf"
+	tracefStr := "Tracef"
+	infoStr := "Info"
+	infofStr := "Infof"
+	warnfStr := "Warnf"
+	errorfStr := "Errorf"
+	fatalfStr := "Fatalf"
+	fatalStr := "Fatal"
+	panicfStr := "Panicf"
+
+	loggerMock.AllowAny(debugfStr, tracefStr, infoStr, infofStr, warnfStr, errorfStr, fatalfStr, fatalStr, panicfStr)
+
+	s.Equal(0, len(loggerMock.Calls))
+
+	loggerMock.Debugf(debugfStr)
+	s.Equal(debugfStr, loggerMock.LastCall())
+	s.Equal(debugfStr, loggerMock.Call(0))
+
+	loggerMock.Tracef(tracefStr)
+	s.Equal(tracefStr, loggerMock.LastCall())
+	s.Equal(tracefStr, loggerMock.Call(1))
+
+	loggerMock.Info(infoStr)
+	s.Equal(infoStr, loggerMock.LastCall())
+	s.Equal(infoStr, loggerMock.Call(2))
+
+	loggerMock.Infof(infofStr)
+	s.Equal(infofStr, loggerMock.LastCall())
+	s.Equal(infofStr, loggerMock.Call(3))
+
+	loggerMock.Warnf(warnfStr)
+	s.Equal(warnfStr, loggerMock.LastCall())
+	s.Equal(warnfStr, loggerMock.Call(4))
+
+	loggerMock.Errorf(errorfStr)
+	s.Equal(errorfStr, loggerMock.LastCall())
+	s.Equal(errorfStr, loggerMock.Call(5))
+
+	loggerMock.Fatalf(fatalfStr)
+	s.Equal(fatalfStr, loggerMock.LastCall())
+	s.Equal(fatalfStr, loggerMock.Call(6))
+
+	loggerMock.Fatal(fatalStr)
+	s.Equal(fatalStr, loggerMock.LastCall())
+	s.Equal(fatalStr, loggerMock.Call(7))
+
+	loggerMock.Panicf(panicfStr)
+	s.Equal(panicfStr, loggerMock.LastCall())
+	s.Equal(panicfStr, loggerMock.Call(8))
+
+	s.Equal(9, len(loggerMock.Calls))
+
+	loggerMock.Clear()
+
+	s.Equal(0, len(loggerMock.Calls))
+}


### PR DESCRIPTION
# Intent 

Fixes two bugs with the `Fatal` function in the mocked logger: 

1. `Fatal` wasn't adding its logging operation to the mock's internal call stack, causing `LastCall()` assertions to fail 
2. Because `Fatal` has a different method signature than the other formatted logging statements, `AllowAny` was failing to register the correct method signature. 

# Automated Tests

I added a new test to validate the change and confirm that the rest of the logging functions use the call stack as expected. The test also implicitly confirms `AllowAny` behavior by allowing all logging operations. 


# Miscellaneous

I added a todo comment in `LoggerMock.AllowAny` which I think could be worth some discussion - the design could totally be the right approach, but I'm just curious why we use string parameters rather than an enumerated type here. 