### PR TITLE
Add Registered Type Matchers for Listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tempvendor
 
 #goland
 .idea/
+
+# Go cache
+.go-cache

--- a/examples/cmd/testnotify/cmd/root.go
+++ b/examples/cmd/testnotify/cmd/root.go
@@ -30,12 +30,13 @@ func init() {
 }
 
 type testNotification struct {
-	Message string
-	UUID    string
+	MessageType uint8
+	Message     string
+	UUID        string
 }
 
 func (t *testNotification) Type() uint8 {
-	return 1
+	return t.MessageType
 }
 
 func (t *testNotification) Guid() string {

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ test-integration *args:
     test_args=${test_args:-./...}
     ${dc} run \
         -e TEST_ARGS="$test_args" \
+        -e GOCACHE=/platform-lib/.go-cache \
         -e DEF_TEST_ARGS="-v" \
         -e MODULE=${MODULE:-""} \
         lib ./scripts/test.sh
@@ -64,6 +65,7 @@ lint:
 build-docker:
     docker run {{ interactive }} --rm \
         -v {{justfile_directory()}}/:/build \
+        -e GOCACHE=/platform-lib/.go-cache \
         -w /build \
         rstudio/platform-lib:lib-build just build
 

--- a/pkg/rsnotify/listener/listener.go
+++ b/pkg/rsnotify/listener/listener.go
@@ -2,36 +2,11 @@ package listener
 
 // Copyright (C) 2022 by RStudio, PBC.
 
-import "encoding/json"
-
 const (
 	// MaxChannelSize sizes for the channel to prevent blocking when distributing
 	// notifications to listeners.
 	MaxChannelSize = 100
 )
-
-// NotifyTypeQueue: Queue work is ready
-// NotifyTypeTx: Latest macro transaction has changed
-// NotifyTypeWorkComplete: Addressed work is complete
-// NotifyTypeSwitchMode: Service mode (online/offline state) switch
-// NotifyTypeChunk: Chunked download chunk is ready
-// NotifyDistroRefresh: Inform the cluster to perform a distro refresh simultaneously
-const (
-	NotifyTypeQueue        = uint8(1)
-	NotifyTypeTx           = uint8(2)
-	NotifyTypeWorkComplete = uint8(3)
-	NotifyTypeSwitchMode   = uint8(4)
-	NotifyTypeChunk        = uint8(5)
-	NotifyDistroRefresh    = uint8(6)
-)
-
-const (
-	ChannelMessages = "messages"
-	ChannelLeader   = "leader"
-	ChannelFollower = "follower"
-)
-
-type Unmarshaller func(n Notification, rawMap map[string]*json.RawMessage) error
 
 type TypeMatcher interface {
 	Field() string
@@ -42,7 +17,6 @@ type TypeMatcher interface {
 type Notification interface {
 	Type() uint8
 	Guid() string
-	Data() interface{}
 }
 
 type Listener interface {
@@ -62,7 +36,6 @@ type DebugLogger interface {
 
 type GenericNotification struct {
 	NotifyGuid string
-	NotifyData interface{}
 	NotifyType uint8
 }
 
@@ -72,10 +45,6 @@ func (n *GenericNotification) Type() uint8 {
 
 func (n *GenericNotification) Guid() string {
 	return n.NotifyGuid
-}
-
-func (n *GenericNotification) Data() interface{} {
-	return n.NotifyData
 }
 
 type GenericMatcher struct {

--- a/pkg/rsnotify/listener/listener.go
+++ b/pkg/rsnotify/listener/listener.go
@@ -3,7 +3,7 @@ package listener
 // Copyright (C) 2022 by RStudio, PBC.
 
 const (
-	// MaxChannelSize sizes for the channel to prevent blocking when distributing
+	// MaxChannelSize sizes the channel to prevent blocking when distributing
 	// notifications to listeners.
 	MaxChannelSize = 100
 )
@@ -26,7 +26,7 @@ type Listener interface {
 }
 
 type Logger interface {
-	Debugf(msg string, argslistenerfactory ...interface{})
+	Debugf(msg string, args ...interface{})
 }
 
 type DebugLogger interface {

--- a/pkg/rsnotify/listener/listener_test.go
+++ b/pkg/rsnotify/listener/listener_test.go
@@ -13,11 +13,3 @@ type NotifySuite struct{}
 var _ = check.Suite(&NotifySuite{})
 
 func TestPackage(t *testing.T) { check.TestingT(t) }
-
-func (s *NotifySuite) TestTypes(c *check.C) {
-	c.Assert(NotifyTypeQueue, check.Equals, uint8(1))
-	c.Assert(NotifyTypeTx, check.Equals, uint8(2))
-	c.Assert(NotifyTypeWorkComplete, check.Equals, uint8(3))
-	c.Assert(NotifyTypeSwitchMode, check.Equals, uint8(4))
-	c.Assert(NotifyTypeChunk, check.Equals, uint8(5))
-}

--- a/pkg/rsnotify/listener/listenertest.go
+++ b/pkg/rsnotify/listener/listenertest.go
@@ -17,10 +17,6 @@ func (t *TestNotification) Guid() string {
 	return t.GuidVal
 }
 
-func (t *TestNotification) Data() interface{} {
-	return t.Val
-}
-
 type TestLogger struct {
 	enabled bool
 }

--- a/pkg/rsnotify/listenerfactory/listenerfactory.go
+++ b/pkg/rsnotify/listenerfactory/listenerfactory.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ListenerFactory interface {
-	New(channel string, dataType listener.Notification) listener.Listener
+	New(channel string, matcher listener.TypeMatcher) listener.Listener
 	RegisterUnmarshaler(dataType uint8, unmarshaler listener.Unmarshaller)
 	Shutdown()
 }

--- a/pkg/rsnotify/listenerfactory/listenerfactory.go
+++ b/pkg/rsnotify/listenerfactory/listenerfactory.go
@@ -3,25 +3,10 @@ package listenerfactory
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"log"
-
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
 )
 
 type ListenerFactory interface {
 	New(channel string, matcher listener.TypeMatcher) listener.Listener
-	RegisterUnmarshaler(dataType uint8, unmarshaler listener.Unmarshaller)
 	Shutdown()
-}
-
-type CommonListenerFactory struct {
-	// A map of registered unmarshallers for the message types we support
-	Unmarshallers map[uint8]listener.Unmarshaller
-}
-
-func (l *CommonListenerFactory) RegisterUnmarshaler(dataType uint8, unmarshaler listener.Unmarshaller) {
-	if _, ok := l.Unmarshallers[dataType]; ok {
-		log.Fatalf("Attempted to register a listener unmarshaler for a type (%d) that is already registered", dataType)
-	}
-	l.Unmarshallers[dataType] = unmarshaler
 }

--- a/pkg/rsnotify/listeners/local/factory.go
+++ b/pkg/rsnotify/listeners/local/factory.go
@@ -4,20 +4,15 @@ package local
 
 import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 )
 
 type ListenerFactory struct {
-	listenerfactory.CommonListenerFactory
 	llf *ListenerProvider
 }
 
 func NewListenerFactory(llf *ListenerProvider) *ListenerFactory {
 	return &ListenerFactory{
 		llf: llf,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	}
 }
 

--- a/pkg/rsnotify/listeners/local/factory.go
+++ b/pkg/rsnotify/listeners/local/factory.go
@@ -23,6 +23,6 @@ func NewListenerFactory(llf *ListenerProvider) *ListenerFactory {
 
 func (l *ListenerFactory) Shutdown() {}
 
-func (l *ListenerFactory) New(channelName string, dataType listener.Notification) listener.Listener {
+func (l *ListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
 	return l.llf.New(channelName)
 }

--- a/pkg/rsnotify/listeners/local/factory_test.go
+++ b/pkg/rsnotify/listeners/local/factory_test.go
@@ -4,9 +4,6 @@ package local
 
 import (
 	"gopkg.in/check.v1"
-
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 )
 
 type ListenerFactorySuite struct{}
@@ -29,8 +26,5 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	l := NewListenerFactory(cstore.GetLocalListenerFactory())
 	c.Check(l, check.DeepEquals, &ListenerFactory{
 		llf: llf,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	})
 }

--- a/pkg/rsnotify/listeners/postgrespgx/factory.go
+++ b/pkg/rsnotify/listeners/postgrespgx/factory.go
@@ -6,12 +6,10 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerutils"
 )
 
 type PgxListenerFactory struct {
-	listenerfactory.CommonListenerFactory
 	pool        *pgxpool.Pool
 	debugLogger listener.DebugLogger
 	listeners   []*PgxListener
@@ -21,9 +19,6 @@ func NewPgxListenerFactory(pool *pgxpool.Pool, debugLogger listener.DebugLogger)
 	return &PgxListenerFactory{
 		pool:        pool,
 		debugLogger: debugLogger,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	}
 }
 
@@ -37,7 +32,7 @@ func (l *PgxListenerFactory) New(channelName string, matcher listener.TypeMatche
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	pgxListener := NewPgxListener(channelName, l.pool, matcher, l.Unmarshallers, l.debugLogger)
+	pgxListener := NewPgxListener(channelName, l.pool, matcher, l.debugLogger)
 	l.listeners = append(l.listeners, pgxListener)
 	return pgxListener
 }

--- a/pkg/rsnotify/listeners/postgrespgx/factory.go
+++ b/pkg/rsnotify/listeners/postgrespgx/factory.go
@@ -28,16 +28,16 @@ func NewPgxListenerFactory(pool *pgxpool.Pool, debugLogger listener.DebugLogger)
 }
 
 func (l *PgxListenerFactory) Shutdown() {
-	for _, listener := range l.listeners {
-		listener.Stop()
+	for _, ll := range l.listeners {
+		ll.Stop()
 	}
 }
 
-func (l *PgxListenerFactory) New(channelName string, dataType listener.Notification) listener.Listener {
+func (l *PgxListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	listener := NewPgxListener(channelName, dataType, l.pool, l.Unmarshallers, l.debugLogger)
-	l.listeners = append(l.listeners, listener)
-	return listener
+	pgxListener := NewPgxListener(channelName, l.pool, matcher, l.Unmarshallers, l.debugLogger)
+	l.listeners = append(l.listeners, pgxListener)
+	return pgxListener
 }

--- a/pkg/rsnotify/listeners/postgrespgx/factory_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/factory_test.go
@@ -7,7 +7,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 )
 
 type ListenerFactorySuite struct{}
@@ -21,8 +20,5 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	c.Check(l2, check.DeepEquals, &PgxListenerFactory{
 		pool:        pool,
 		debugLogger: lgr,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	})
 }

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -19,26 +19,24 @@ import (
 )
 
 type PgxListener struct {
-	name          string
-	pool          *pgxpool.Pool
-	conn          *pgxpool.Conn
-	cancel        context.CancelFunc
-	exit          chan struct{}
-	unmarshallers map[uint8]listener.Unmarshaller
-	matcher       listener.TypeMatcher
-	ip            string
-	debugLogger   listener.DebugLogger
+	name        string
+	pool        *pgxpool.Pool
+	conn        *pgxpool.Conn
+	cancel      context.CancelFunc
+	exit        chan struct{}
+	matcher     listener.TypeMatcher
+	ip          string
+	debugLogger listener.DebugLogger
 }
 
 // NewPgxListener creates a new listener.
 // Only intended to be called from a listener factory's `New` method.
-func NewPgxListener(name string, pool *pgxpool.Pool, matcher listener.TypeMatcher, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PgxListener {
+func NewPgxListener(name string, pool *pgxpool.Pool, matcher listener.TypeMatcher, debugLogger listener.DebugLogger) *PgxListener {
 	return &PgxListener{
-		name:          name,
-		pool:          pool,
-		debugLogger:   debugLogger,
-		unmarshallers: unmarshallers,
-		matcher:       matcher,
+		name:        name,
+		pool:        pool,
+		debugLogger: debugLogger,
+		matcher:     matcher,
 	}
 }
 
@@ -208,14 +206,6 @@ func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan
 	if err != nil {
 		errs <- fmt.Errorf("error unmarshalling JSON: %s", err)
 		return
-	}
-	if unmarshaler, ok := l.unmarshallers[input.Type()]; ok {
-		err = unmarshaler(input, tmp)
-		if err != nil {
-			errs <- fmt.Errorf("error unmarshalling with custom unmarshaller: %s", err)
-			return
-		}
-		l.Debugf("Unmarshalled notification of type %d with registered unmarshaller", input.Type())
 	}
 	items <- input
 }

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4/pgxpool"
-
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
 )
 
@@ -23,22 +22,23 @@ type PgxListener struct {
 	name          string
 	pool          *pgxpool.Pool
 	conn          *pgxpool.Conn
-	t             listener.Notification
 	cancel        context.CancelFunc
 	exit          chan struct{}
 	unmarshallers map[uint8]listener.Unmarshaller
+	matcher       listener.TypeMatcher
 	ip            string
 	debugLogger   listener.DebugLogger
 }
 
-// Only intended to be called from listenerfactory.go's `New` method.
-func NewPgxListener(name string, i listener.Notification, pool *pgxpool.Pool, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PgxListener {
+// NewPgxListener creates a new listener.
+// Only intended to be called from a listener factory's `New` method.
+func NewPgxListener(name string, pool *pgxpool.Pool, matcher listener.TypeMatcher, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PgxListener {
 	return &PgxListener{
 		name:          name,
 		pool:          pool,
-		t:             i,
 		debugLogger:   debugLogger,
 		unmarshallers: unmarshallers,
+		matcher:       matcher,
 	}
 }
 
@@ -113,7 +113,7 @@ func (l *PgxListener) wait(ctx context.Context, items chan listener.Notification
 			return
 		}
 
-		l.notify(n, l.t, errs, items)
+		l.notify(n, errs, items)
 	}
 }
 
@@ -170,18 +170,40 @@ func (l *PgxListener) Debugf(msg string, args ...interface{}) {
 	}
 }
 
-func (l *PgxListener) notify(n *pgconn.Notification, i interface{}, errs chan error, items chan listener.Notification) {
+func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan listener.Notification) {
 	// A notification was received! Unmarshal it into the correct type and send it.
 	var input listener.Notification
-	input = reflect.New(reflect.ValueOf(i).Elem().Type()).Interface().(listener.Notification)
+
+	// Convert postgres message payload to byte array
 	payloadBytes := []byte(n.Payload)
-	err := json.Unmarshal(payloadBytes, input)
+
+	// Unmarshal the payload to a raw message
+	var tmp map[string]*json.RawMessage
+	err := json.Unmarshal(payloadBytes, &tmp)
+	if err != nil {
+		errs <- fmt.Errorf("error unmarshalling raw message: %s", err)
+	}
+
+	// Unmarshal request data type
+	var dataType uint8
+	if tmp[l.matcher.Field()] == nil {
+		errs <- fmt.Errorf("message does not contain data type field %s", l.matcher.Field())
+	}
+	if err = json.Unmarshal(*tmp[l.matcher.Field()], &dataType); err != nil {
+		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
+	}
+
+	// Get an object of the correct type
+	input = reflect.New(reflect.ValueOf(l.matcher.Type(dataType)).Elem().Type()).Interface().(listener.Notification)
+
+	// Unmarshal the payload
+	err = json.Unmarshal(payloadBytes, input)
 	if err != nil {
 		errs <- fmt.Errorf("error unmarshalling JSON: %s", err)
 		return
 	}
-	if unmarshaller, ok := l.unmarshallers[input.Type()]; ok {
-		err = unmarshaller(input, payloadBytes)
+	if unmarshaler, ok := l.unmarshallers[input.Type()]; ok {
+		err = unmarshaler(input, tmp)
 		if err != nil {
 			errs <- fmt.Errorf("error unmarshalling with custom unmarshaller: %s", err)
 			return

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
@@ -21,6 +21,16 @@ var _ = check.Suite(&PgxNotifySuite{})
 
 func TestPackage(t *testing.T) { check.TestingT(t) }
 
+type testNotification struct {
+	listener.GenericNotification
+	Val string
+}
+
+type testNotificationAlt struct {
+	listener.GenericNotification
+	Val uint64
+}
+
 func (s *PgxNotifySuite) SetUpSuite(c *check.C) {
 	if testing.Short() {
 		c.Skip("skipping pgx notification tests because -short was provided")
@@ -41,23 +51,20 @@ func (s *PgxNotifySuite) TearDownSuite(c *check.C) {
 
 func (s *PgxNotifySuite) TestNewPgxListener(c *check.C) {
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
+	matcher := listener.NewMatcher("NotifyType")
+	matcher.Register(2, &testNotification{})
 	lgr := &listener.TestLogger{}
-	l := NewPgxListener("test-a", &testNotification{}, s.pool, unmarshallers, lgr)
+	l := NewPgxListener("test-a", s.pool, matcher, unmarshallers, lgr)
 	c.Check(l, check.DeepEquals, &PgxListener{
 		name:          "test-a",
 		pool:          s.pool,
-		t:             &testNotification{},
+		matcher:       matcher,
 		unmarshallers: unmarshallers,
 		debugLogger:   lgr,
 	})
 }
 
-type testNotification struct {
-	listener.GenericNotification
-	Val string
-}
-
-func (s *PgxNotifySuite) notify(channel string, n *testNotification, c *check.C) {
+func (s *PgxNotifySuite) notify(channel string, n interface{}, c *check.C) {
 	err := Notify(channel, n, s.pool)
 	c.Assert(err, check.IsNil)
 }
@@ -65,27 +72,41 @@ func (s *PgxNotifySuite) notify(channel string, n *testNotification, c *check.C)
 func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 	defer leaktest.Check(c)()
 
+	matcher := listener.NewMatcher("NotifyType")
+	matcher.Register(2, &testNotification{})
+	matcher.Register(3, &testNotificationAlt{})
+
 	tn := testNotification{
-		Val: "test-notification",
+		GenericNotification: listener.GenericNotification{NotifyType: 2},
+		Val:                 "test-notification",
 	}
 
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
 
-	l := NewPgxListener("test-a", &tn, s.pool, unmarshallers, nil)
+	l := NewPgxListener("test-a", s.pool, matcher, unmarshallers, nil)
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
 	c.Assert(err, check.IsNil)
 	done := make(chan struct{})
-	count := 0
+	count1 := 0
+	count2 := 0
 	go func() {
 		defer close(done)
 		for {
 			select {
 			case i := <-data:
-				c.Assert(i.(*testNotification).Val, check.Equals, "test-notification")
-				count++
-				if count == 2 {
+				switch m := i.(type) {
+				case *testNotification:
+					c.Assert(m.Val, check.Equals, "test-notification")
+					count1++
+				case *testNotificationAlt:
+					c.Assert(m.Val, check.Equals, uint64(999))
+					count2++
+				}
+				if count1 == 2 && count2 == 1 {
+					// Return when we've received 2 notifications of *testNotification type
+					// and 1 notification of the *testNotificationAlt type
 					return
 				}
 			case e := <-errs:
@@ -98,9 +119,17 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 	// Send some data across the main test channel.
 	s.notify("test-a", &tn, c)
 	// Send some data across a different channel. This should not be seen
-	s.notify("test-b", &testNotification{Val: "different-test"}, c)
+	s.notify("test-b", &testNotification{
+		GenericNotification: listener.GenericNotification{NotifyType: 2},
+		Val:                 "different-test",
+	}, c)
 	// Send more data across the main test channel.
 	s.notify("test-a", &tn, c)
+	// Send data of an alternate type across the main test channel
+	s.notify("test-a", &testNotificationAlt{
+		GenericNotification: listener.GenericNotification{NotifyType: 3},
+		Val:                 999,
+	}, c)
 	c.Assert(err, check.IsNil)
 
 	// Wait for test to complete
@@ -140,7 +169,10 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 	}()
 
 	// This notification should be received.
-	s.notify("test-a", &testNotification{Val: "second-test"}, c)
+	s.notify("test-a", &testNotification{
+		GenericNotification: listener.GenericNotification{NotifyType: 2},
+		Val:                 "second-test",
+	}, c)
 	c.Assert(err, check.IsNil)
 
 	// Wait for test to complete
@@ -153,13 +185,17 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 	defer leaktest.Check(c)()
 
+	matcher := listener.NewMatcher("NotifyType")
+	matcher.Register(3, &testNotification{})
+
 	tn := testNotification{
-		Val: "test-notification",
+		GenericNotification: listener.GenericNotification{NotifyType: 3},
+		Val:                 "test-notification",
 	}
 
 	unmarshallers := make(map[uint8]listener.Unmarshaller)
 
-	l := NewPgxListener("test-a", &tn, s.pool, unmarshallers, nil)
+	l := NewPgxListener("test-a", s.pool, matcher, unmarshallers, nil)
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -192,7 +228,10 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 		// Send some data across the main test channel.
 		s.notify("test-a", &tn, c)
 		// Send some data across a different channel. This should not be seen
-		s.notify("test-b", &testNotification{Val: "different-test"}, c)
+		s.notify("test-b", &testNotification{
+			GenericNotification: listener.GenericNotification{NotifyType: 3},
+			Val:                 "different-test",
+		}, c)
 	}
 
 	// Block receiving any notifications until all have been sent

--- a/pkg/rsnotify/listeners/postgrespgx/pgxtest.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxtest.go
@@ -34,3 +34,10 @@ func Notify(channelName string, n interface{}, pool *pgxpool.Pool) error {
 	_, err = pool.Exec(context.Background(), query, msg)
 	return err
 }
+
+func NotifyRaw(channelName string, msg string, pool *pgxpool.Pool) error {
+	query := fmt.Sprintf(
+		"select pg_notify('%s', $1)", channelName)
+	_, err := pool.Exec(context.Background(), query, msg)
+	return err
+}

--- a/pkg/rsnotify/listeners/postgrespq/factory.go
+++ b/pkg/rsnotify/listeners/postgrespq/factory.go
@@ -4,12 +4,10 @@ package postgrespq
 
 import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerutils"
 )
 
 type PqListenerFactory struct {
-	listenerfactory.CommonListenerFactory
 	factory     PqRetrieveListenerFactory
 	debugLogger listener.DebugLogger
 	listeners   []*PqListener
@@ -19,9 +17,6 @@ func NewPqListenerFactory(factory PqRetrieveListenerFactory, debugLogger listene
 	return &PqListenerFactory{
 		factory:     factory,
 		debugLogger: debugLogger,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	}
 }
 
@@ -35,7 +30,7 @@ func (l *PqListenerFactory) New(channelName string, matcher listener.TypeMatcher
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	listener := NewPqListener(channelName, l.factory, matcher, l.Unmarshallers, l.debugLogger)
+	listener := NewPqListener(channelName, l.factory, matcher, l.debugLogger)
 	l.listeners = append(l.listeners, listener)
 	return listener
 }

--- a/pkg/rsnotify/listeners/postgrespq/factory.go
+++ b/pkg/rsnotify/listeners/postgrespq/factory.go
@@ -31,11 +31,11 @@ func (l *PqListenerFactory) Shutdown() {
 	}
 }
 
-func (l *PqListenerFactory) New(channelName string, dataType listener.Notification) listener.Listener {
+func (l *PqListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	listener := NewPqListener(channelName, dataType, l.factory, l.Unmarshallers, l.debugLogger)
+	listener := NewPqListener(channelName, l.factory, matcher, l.Unmarshallers, l.debugLogger)
 	l.listeners = append(l.listeners, listener)
 	return listener
 }

--- a/pkg/rsnotify/listeners/postgrespq/factory_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/factory_test.go
@@ -6,7 +6,6 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listener"
-	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerfactory"
 )
 
 type ListenerFactorySuite struct{}
@@ -20,8 +19,5 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	c.Check(l3, check.DeepEquals, &PqListenerFactory{
 		factory:     fakeFactory,
 		debugLogger: lgr,
-		CommonListenerFactory: listenerfactory.CommonListenerFactory{
-			Unmarshallers: make(map[uint8]listener.Unmarshaller),
-		},
 	})
 }

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -24,22 +24,22 @@ type PqListener struct {
 	name          string
 	factory       PqRetrieveListenerFactory
 	conn          *pq.Listener
-	t             listener.Notification
 	cancel        context.CancelFunc
 	exit          chan struct{}
 	unmarshallers map[uint8]listener.Unmarshaller
+	matcher       listener.TypeMatcher
 	ip            string
 	debugLogger   listener.DebugLogger
 }
 
 // Only intended to be called from listenerfactory.go's `New` method.
-func NewPqListener(name string, i listener.Notification, factory PqRetrieveListenerFactory, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
+func NewPqListener(name string, factory PqRetrieveListenerFactory, matcher listener.TypeMatcher, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
 	return &PqListener{
 		name:          name,
 		factory:       factory,
-		t:             i,
 		debugLogger:   debugLogger,
 		unmarshallers: unmarshallers,
+		matcher:       matcher,
 	}
 }
 
@@ -102,7 +102,7 @@ func (l *PqListener) wait(ctx context.Context, items chan listener.Notification,
 	for {
 		select {
 		case n := <-ch:
-			l.notify(n, l.t, errs, items)
+			l.notify(n, errs, items)
 		case <-ctx.Done():
 			return
 		}
@@ -153,18 +153,40 @@ func (l *PqListener) Debugf(msg string, args ...interface{}) {
 	}
 }
 
-func (l *PqListener) notify(n *pq.Notification, i interface{}, errs chan error, items chan listener.Notification) {
+func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan listener.Notification) {
 	// A notification was received! Unmarshal it into the correct type and send it.
 	var input listener.Notification
-	input = reflect.New(reflect.ValueOf(i).Elem().Type()).Interface().(listener.Notification)
+
+	// Convert postgres message payload to byte array
 	payloadBytes := []byte(n.Extra)
-	err := json.Unmarshal(payloadBytes, input)
+
+	// Unmarshal the payload to a raw message
+	var tmp map[string]*json.RawMessage
+	err := json.Unmarshal(payloadBytes, &tmp)
+	if err != nil {
+		errs <- fmt.Errorf("error unmarshalling raw message: %s", err)
+	}
+
+	// Unmarshal request data type
+	var dataType uint8
+	if tmp[l.matcher.Field()] == nil {
+		errs <- fmt.Errorf("message does not contain data type field %s", l.matcher.Field())
+	}
+	if err = json.Unmarshal(*tmp[l.matcher.Field()], &dataType); err != nil {
+		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
+	}
+
+	// Get an object of the correct type
+	input = reflect.New(reflect.ValueOf(l.matcher.Type(dataType)).Elem().Type()).Interface().(listener.Notification)
+
+	// Unmarshal the payload
+	err = json.Unmarshal(payloadBytes, input)
 	if err != nil {
 		errs <- fmt.Errorf("error unmarshalling JSON: %s", err)
 		return
 	}
-	if unmarshaller, ok := l.unmarshallers[input.Type()]; ok {
-		err = unmarshaller(input, payloadBytes)
+	if unmarshaler, ok := l.unmarshallers[input.Type()]; ok {
+		err = unmarshaler(input, tmp)
 		if err != nil {
 			errs <- fmt.Errorf("error unmarshalling with custom unmarshaller: %s", err)
 			return

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -178,6 +178,10 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
 		return
 	}
+	if l.matcher.Type(dataType) == nil {
+		errs <- fmt.Errorf("no matcher type found for %d", dataType)
+		return
+	}
 
 	// Get an object of the correct type
 	input = reflect.New(reflect.ValueOf(l.matcher.Type(dataType)).Elem().Type()).Interface().(listener.Notification)

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -21,25 +21,23 @@ type PqRetrieveListenerFactory interface {
 }
 
 type PqListener struct {
-	name          string
-	factory       PqRetrieveListenerFactory
-	conn          *pq.Listener
-	cancel        context.CancelFunc
-	exit          chan struct{}
-	unmarshallers map[uint8]listener.Unmarshaller
-	matcher       listener.TypeMatcher
-	ip            string
-	debugLogger   listener.DebugLogger
+	name        string
+	factory     PqRetrieveListenerFactory
+	conn        *pq.Listener
+	cancel      context.CancelFunc
+	exit        chan struct{}
+	matcher     listener.TypeMatcher
+	ip          string
+	debugLogger listener.DebugLogger
 }
 
 // Only intended to be called from listenerfactory.go's `New` method.
-func NewPqListener(name string, factory PqRetrieveListenerFactory, matcher listener.TypeMatcher, unmarshallers map[uint8]listener.Unmarshaller, debugLogger listener.DebugLogger) *PqListener {
+func NewPqListener(name string, factory PqRetrieveListenerFactory, matcher listener.TypeMatcher, debugLogger listener.DebugLogger) *PqListener {
 	return &PqListener{
-		name:          name,
-		factory:       factory,
-		debugLogger:   debugLogger,
-		unmarshallers: unmarshallers,
-		matcher:       matcher,
+		name:        name,
+		factory:     factory,
+		debugLogger: debugLogger,
+		matcher:     matcher,
 	}
 }
 
@@ -191,14 +189,6 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 	if err != nil {
 		errs <- fmt.Errorf("error unmarshalling JSON: %s", err)
 		return
-	}
-	if unmarshaler, ok := l.unmarshallers[input.Type()]; ok {
-		err = unmarshaler(input, tmp)
-		if err != nil {
-			errs <- fmt.Errorf("error unmarshalling with custom unmarshaller: %s", err)
-			return
-		}
-		l.Debugf("Unmarshalled notification of type %d with registered unmarshaller", input.Type())
 	}
 	items <- input
 }

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -165,15 +165,18 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 	err := json.Unmarshal(payloadBytes, &tmp)
 	if err != nil {
 		errs <- fmt.Errorf("error unmarshalling raw message: %s", err)
+		return
 	}
 
 	// Unmarshal request data type
 	var dataType uint8
 	if tmp[l.matcher.Field()] == nil {
 		errs <- fmt.Errorf("message does not contain data type field %s", l.matcher.Field())
+		return
 	}
 	if err = json.Unmarshal(*tmp[l.matcher.Field()], &dataType); err != nil {
 		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
+		return
 	}
 
 	// Get an object of the correct type

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
@@ -3,7 +3,10 @@ package postgrespq
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
+	"encoding/json"
+	"errors"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/fortytw2/leaktest"
@@ -45,6 +48,11 @@ type testNotificationAlt struct {
 
 func (s *PqNotifySuite) notify(channel string, n interface{}, c *check.C) {
 	err := Notify(channel, n, s.db)
+	c.Assert(err, check.IsNil)
+}
+
+func (s *PqNotifySuite) notifyRaw(channel string, message string, c *check.C) {
+	err := NotifyRaw(channel, message, s.db)
 	c.Assert(err, check.IsNil)
 }
 
@@ -190,6 +198,101 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 		Val:                 "second-test",
 	}, c)
 	c.Assert(err, check.IsNil)
+
+	// Wait for test to complete
+	<-done
+
+	// Clean up
+	l.Stop()
+}
+
+func (s *PqNotifySuite) TestNotificationsErrors(c *check.C) {
+	defer leaktest.Check(c)()
+
+	matcher := listener.NewMatcher("NotifyType")
+	matcher.Register(2, &testNotification{})
+
+	// A notification that is invalid JSON and cannot be unmarshaled
+	tnBytesInvalid := "{!"
+
+	// A notification that does not contain the NotifyType field
+	tnNoTypeField := struct {
+		Value string
+	}{
+		Value: "test",
+	}
+
+	// A notification whose data type field cannot be unmarshalled to a uint8
+	tnBytesInvalidTypeData := `{"NotifyType":{"name":"jon"}}`
+
+	// A notification of an unregistered type
+	tnWrongType := testNotification{
+		GenericNotification: listener.GenericNotification{NotifyType: 4},
+		Val:                 "test-notification",
+	}
+
+	// A notification of a registered type that matches a failing marshaller
+	tnMarshallerFails := &testNotification{
+		GenericNotification: listener.GenericNotification{
+			NotifyType: 2,
+		},
+		Val: "test",
+	}
+
+	// A notification with a valid type, but that fails unmarshalling to the expected type
+	tnBytesCannotUnmarshal := `{"NotifyType":2,"Val":{"is":"unexpected_object"}}`
+
+	// Register a marshaller that will fail
+	unmarshallers := map[uint8]listener.Unmarshaller{
+		2: func(n listener.Notification, rawMap map[string]*json.RawMessage) error {
+			return errors.New("unmarshal error")
+		},
+	}
+
+	l := NewPqListener("test-a", s.factory, matcher, unmarshallers, nil)
+
+	// Listen for notifications
+	data, errs, err := l.Listen()
+	c.Assert(err, check.IsNil)
+	done := make(chan struct{})
+	counts := make(map[string]bool)
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-data:
+				log.Printf("unexpected good data")
+				c.FailNow()
+			case e := <-errs:
+				errStr := e.Error()
+				switch {
+				case strings.HasPrefix(errStr, "error unmarshalling raw message"):
+					counts["firstUnmarshal"] = true
+				case strings.HasPrefix(errStr, "message does not contain data type field NotifyType"):
+					counts["missingType"] = true
+				case strings.HasPrefix(errStr, "error unmarshalling message data type"):
+					counts["badType"] = true
+				case strings.HasPrefix(errStr, "no matcher type found for 4"):
+					counts["noMatcher"] = true
+				case strings.HasPrefix(errStr, "error unmarshalling JSON:"):
+					counts["secondUnmarshal"] = true
+				case strings.HasPrefix(errStr, "error unmarshalling with custom unmarshaller: unmarshal error"):
+					counts["unmarshalerFails"] = true
+				}
+				if len(counts) == 6 {
+					return
+				}
+			}
+		}
+	}()
+
+	// Send data across the main test channel. All should err.
+	s.notifyRaw("test-a", tnBytesInvalid, c)
+	s.notify("test-a", &tnNoTypeField, c)
+	s.notifyRaw("test-a", tnBytesInvalidTypeData, c)
+	s.notify("test-a", &tnWrongType, c)
+	s.notifyRaw("test-a", tnBytesCannotUnmarshal, c)
+	s.notify("test-a", &tnMarshallerFails, c)
 
 	// Wait for test to complete
 	<-done

--- a/pkg/rsnotify/listeners/postgrespq/pqtest.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqtest.go
@@ -35,3 +35,10 @@ func Notify(channelName string, n interface{}, db *sqlx.DB) error {
 	_, err = db.Exec(query, msg)
 	return err
 }
+
+func NotifyRaw(channelName string, msg string, db *sqlx.DB) error {
+	query := fmt.Sprintf(
+		"select pg_notify('%s', $1)", channelName)
+	_, err := db.Exec(query, msg)
+	return err
+}


### PR DESCRIPTION
Historically, when you create a listener to receive notifications on a channel, that listener is bound to a single type. This makes it difficult to reuse a single DB connection for different notification types.

This PR adds the ability to register multiple types for a single listener. The type matcher provides the listener with the ability to listen for multiple types reliably.