### PR TITLE
Fix concurrent writes to debug callbacks registry

### DIFF
--- a/examples/cmd/testapp/cmd/debug.go
+++ b/examples/cmd/testapp/cmd/debug.go
@@ -22,11 +22,22 @@ var DebugCmd = &cobra.Command{
 	Short:   "Command to debug log some information",
 	Example: "",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		debugLogger := rslog.NewDebugLogger(TestDebug)
-		// Log a debug-level debug message for the `TestDebug` product region.
-		debugLogger.Debugf(fmt.Sprintf("Debug Message: %s", message))
-		// Also log a trace-level debug message for the `TestDebug` product region.
-		debugLogger.Tracef(fmt.Sprintf("Trace Message: %s", message))
+		go func() {
+			debugLogger := rslog.NewDebugLogger(TestDebug)
+			// Log a debug-level debug message for the `TestDebug` product region.
+			debugLogger.Debugf(fmt.Sprintf("Debug Message: %s", message))
+			// Also log a trace-level debug message for the `TestDebug` product region.
+			debugLogger.Tracef(fmt.Sprintf("Trace Message: %s", message))
+		}()
+
+		go func() {
+			debugLogger := rslog.NewDebugLogger(TestDebug)
+			// Log a debug-level debug message for the `TestDebug` product region.
+			debugLogger.Debugf(fmt.Sprintf("Second Debug Message: %s", message))
+			// Also log a trace-level debug message for the `TestDebug` product region.
+			debugLogger.Tracef(fmt.Sprintf("Second Trace Message: %s", message))
+		}()
+
 		return nil
 	},
 }

--- a/pkg/rslog/debug.go
+++ b/pkg/rslog/debug.go
@@ -148,6 +148,9 @@ func NewDebugLogger(region ProductRegion) *debugLogger {
 }
 
 func registerLoggerCb(region ProductRegion, cb func(bool)) {
+	debugMutex.Lock()
+	defer debugMutex.Unlock()
+
 	regionCallbacks[region] = append(regionCallbacks[region], cb)
 }
 


### PR DESCRIPTION
Implement mutex lock to prevent concurrency issues with debug logger callbacks registry. Noticed at https://github.com/rstudio/connect/issues/20795