### PR TITLE
Prevent hanging behaivour when calculating file storage disk usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ out/
 # Directory used while generating NOTICE.md
 tempvendor
 
-#goland
+# IDE specific dirs
 .idea/
+.vscode
 
 # Go cache
 .go-cache

--- a/pkg/rsstorage/internal/integration_test/chunks_test.go
+++ b/pkg/rsstorage/internal/integration_test/chunks_test.go
@@ -88,7 +88,7 @@ func (s *ChunksIntegrationSuite) NewServerSet(c *check.C, class, prefix string) 
 	debugLogger := &servertest.TestLogger{}
 	pgServer := postgres.NewPgStorageServer(class, 100*1024, wn, wn, s.pool, debugLogger)
 	s3Server := s3server.NewS3StorageServer(class, "", s3Svc, 100*1024, wn, wn)
-	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute)
+	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute, time.Minute)
 
 	return map[string]rsstorage.StorageServer{
 		"file":     rsstorage.NewMetadataStorageServer("file", fileServer, cstore),
@@ -227,7 +227,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	debugLogger := &servertest.TestLogger{}
-	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute)
+	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute, time.Minute)
 
 	cw := &internal.DefaultChunkUtils{
 		ChunkSize:   chunkSize,
@@ -321,7 +321,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialTimeout(c *check.C) {
 	}
 
 	debugLogger := &servertest.TestLogger{}
-	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute)
+	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, "chunks", debugLogger, time.Minute, time.Minute)
 
 	cw := &internal.DefaultChunkUtils{
 		ChunkSize:   chunkSize,

--- a/pkg/rsstorage/internal/integration_test/integration.go
+++ b/pkg/rsstorage/internal/integration_test/integration.go
@@ -4,6 +4,7 @@ package integrationtest
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 
@@ -32,7 +33,7 @@ func getStorageServerAttempt(cfg *rsstorage.Config, class string, destination st
 			return nil, fmt.Errorf("Missing [FileStorage \"%s\"] configuration section", class)
 		}
 		//todo bioc: configurable size here
-		server = file.NewFileStorageServer(cfg.File.Location, cfg.ChunkSizeBytes, waiter, notifier, class, debugLogger, cfg.CacheTimeout)
+		server = file.NewFileStorageServer(cfg.File.Location, cfg.ChunkSizeBytes, waiter, notifier, class, debugLogger, cfg.CacheTimeout, 30*time.Second)
 	case "s3":
 		if cfg.S3 == nil {
 			return nil, fmt.Errorf("Missing [S3Storage \"%s\"] configuration section", class)

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -160,7 +160,7 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 	debugLogger := &servertest.TestLogger{}
 	pgServer := postgres.NewPgStorageServer(class, 100*1024, wn, wn, s.pool, debugLogger)
 	s3Server := s3server.NewS3StorageServer(class, "", s3Svc, 100*1024, wn, wn)
-	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, class, debugLogger, time.Minute)
+	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, class, debugLogger, time.Minute, time.Minute)
 
 	return map[string]rsstorage.StorageServer{
 		"file":     rsstorage.NewMetadataStorageServer("file", fileServer, cstore),

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -144,7 +144,8 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 	defer close(stop)
 
 	sizeChan := make(chan datasize.ByteSize)
-	errChan := make(chan error)
+	// errChan should have a buffer of two items to prevent deadlock between `<-stop` and `errChan<-err`
+	errChan := make(chan error, 2)
 
 	go func(stop <-chan bool, sizeChan chan<- datasize.ByteSize, errChan chan<- error) {
 		err = filepath.Walk(duPath, func(path string, info os.FileInfo, err error) error {
@@ -348,7 +349,8 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 	defer close(stop)
 
 	itemChan := make(chan *types.StoredItem)
-	errChan := make(chan error)
+	// errChan should have a buffer of two items to prevent deadlock between `<-stop` and `errChan<-err`
+	errChan := make(chan error, 2)
 
 	go func(stop <-chan bool, itemChan chan<- *types.StoredItem, errChan chan<- error) {
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -360,7 +361,7 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 		defer close(itemChan)
 		defer close(errChan)
 
-		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		err := filepath.WalkDir(dir, func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
 				log.Printf("Error enumerating storage for directory %s: %s", dir, err)
 				return nil

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -141,14 +141,14 @@ func (s *StorageServer) CalculateUsage() (types.Usage, error) {
 // diskUsage will walk the specified path in a filesystem and
 // aggregate the size of the contained files.
 func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size datasize.ByteSize, err error) {
-	stop := make(chan bool)
+	stop := make(chan struct{})
 	defer close(stop)
 
 	sizeChan := make(chan datasize.ByteSize)
 	// errChan should have a buffer of two items to prevent deadlock between `<-stop` and `errChan<-err`
 	errChan := make(chan error, 2)
 
-	go func(stop <-chan bool, sizeChan chan<- datasize.ByteSize, errChan chan<- error) {
+	go func(stop <-chan struct{}, sizeChan chan<- datasize.ByteSize, errChan chan<- error) {
 		err = filepath.Walk(duPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -349,14 +349,14 @@ func (s *StorageServer) Enumerate() ([]types.StoredItem, error) {
 }
 
 func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error) {
-	stop := make(chan bool)
+	stop := make(chan struct{})
 	defer close(stop)
 
 	itemChan := make(chan *types.StoredItem)
 	// errChan should have a buffer of two items to prevent deadlock between `<-stop` and `errChan<-err`
 	errChan := make(chan error, 2)
 
-	go func(stop <-chan bool, itemChan chan<- *types.StoredItem, errChan chan<- error) {
+	go func(stop <-chan struct{}, itemChan chan<- *types.StoredItem, errChan chan<- error) {
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				log.Printf("Error enumerating storage for directory %s: %s", dir, err)

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -188,7 +188,7 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 			time.Sleep(walkCheckTime)
 		}
 
-		if time.Now().Sub(start) > walkTimeout {
+		if walkTimeout > 0 && time.Now().Sub(start) > walkTimeout {
 			return 0, walktimeoutErr
 		}
 	}

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -188,6 +188,10 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 	start := time.Now()
 
 	for {
+		if walkTimeout > 0 && time.Now().Sub(start) > walkTimeout {
+			return 0, walktimeoutErr
+		}
+
 		select {
 		case <-cacheTimeoutTimer.C:
 			return 0, cacheTimeoutErr
@@ -199,10 +203,6 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 			return
 		default:
 			time.Sleep(walkCheckTime)
-		}
-
-		if walkTimeout > 0 && time.Now().Sub(start) > walkTimeout {
-			return 0, walktimeoutErr
 		}
 	}
 }

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -149,6 +149,9 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 	errChan := make(chan error, 2)
 
 	go func(stop <-chan struct{}, sizeChan chan<- datasize.ByteSize, errChan chan<- error) {
+		defer close(sizeChan)
+		defer close(errChan)
+
 		err = filepath.Walk(duPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
@@ -170,9 +173,6 @@ func diskUsage(duPath string, cacheTimeout, walkTimeout time.Duration) (size dat
 		if err != nil {
 			errChan <- err
 		}
-
-		defer close(sizeChan)
-		defer close(errChan)
 	}(stop, sizeChan, errChan)
 
 	cacheTimeoutTimer := time.NewTimer(cacheTimeout)
@@ -357,6 +357,9 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 	errChan := make(chan error, 2)
 
 	go func(stop <-chan struct{}, itemChan chan<- *types.StoredItem, errChan chan<- error) {
+		defer close(itemChan)
+		defer close(errChan)
+
 		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				log.Printf("Error enumerating storage for directory %s: %s", dir, err)
@@ -386,9 +389,6 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 		if err != nil {
 			errChan <- err
 		}
-
-		defer close(itemChan)
-		defer close(errChan)
 	}(stop, itemChan, errChan)
 
 	items := make([]types.StoredItem, 0)

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -53,7 +53,7 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 		Ch: make(chan bool, 1),
 	}
 	debugLogger := &servertest.TestLogger{}
-	server := NewFileStorageServer("test", 4096, wn, wn, "classname", debugLogger, time.Minute)
+	server := NewFileStorageServer("test", 4096, wn, wn, "classname", debugLogger, time.Minute, time.Minute)
 
 	c.Check(server, check.DeepEquals, &StorageServer{
 		dir:    "test",

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -728,7 +728,7 @@ func (s *FileStorageServerSuite) TestDiskUsage(c *check.C) {
 		defer os.Remove(f.Name())
 	}
 
-	sz, err := diskUsage("testdata", time.Minute, time.Minute)
+	sz, err := diskUsage("testdata", time.Minute, time.Second)
 	c.Assert(err, check.IsNil)
 	c.Check(uint64(sz), check.Equals, uint64(expectedSize))
 }

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -64,6 +64,7 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 				dir:          "test",
 				fileIO:       &defaultFileIO{},
 				cacheTimeout: time.Minute,
+				walkTimeout:  time.Minute,
 				class:        "classname",
 				debugLogger:  debugLogger,
 			},
@@ -73,6 +74,7 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 			MaxAttempts: rsstorage.DefaultMaxChunkAttempts,
 		},
 		cacheTimeout: time.Minute,
+		walkTimeout:  time.Minute,
 		class:        "classname",
 		debugLogger:  debugLogger,
 	})


### PR DESCRIPTION
This issue is intended to prevent infinite hangs due to filesystem locking issues. Here:

- [x] Add `walkTimeout` to `diskUsage` and `enumerate` functions
- [x] Add new internal `enumerate` function to make testing the walk easier
- [x] Run the `filesystem.Walk` in a separate goroutine using channels to perform two-way communication
- [x] Add new `walkTimeout` argument to `NewFileStorageServer`

~If this looks good, I'll also update the `Enumerate()` function similarly.~

**Note:** The point of the `cacheTimeout` was to prevent the `diskUsage` function from hanging longer than our scheduler if the file directory was massive. The new `walkTimeout` variable is meant to be a sanity check, e.g. calculating the size of a single file should never take more than say 15 - 30s.

This will be the first part of: https://github.com/rstudio/package-manager/issues/7475, I'll also make a change in RSPM to stop blocking start-up until after the file storage calculation finishes.