### PR TITLE
Refactor rsnotify and rsstorage New* Methods with arg structs

### DIFF
--- a/examples/cmd/markdownRenderer/main.go
+++ b/examples/cmd/markdownRenderer/main.go
@@ -106,7 +106,7 @@ func main() {
 	// Start a new local listener provider and factory. The provider knows how
 	// to create a new listener. The factory uses the provider to create new
 	// listeners when needed.
-	localListenerProvider := local.NewListenerProviderWithLogger(notifyLogger)
+	localListenerProvider := local.NewListenerProvider(local.ListenerProviderArgs{DebugLogger: notifyLogger})
 	localListenerFactory := local.NewListenerFactory(localListenerProvider)
 	defer localListenerFactory.Shutdown()
 
@@ -163,7 +163,16 @@ func main() {
 	// been written.
 	notifier := storage.NewExampleChunkNotifier(exampleStore)
 	// Create storage server for storing data on disk.
-	fileStorage := file.NewFileStorageServer("data", storageChunkSize, waiter, notifier, "rendered", storageLogger, storageCacheTimeout, storageWalkTimeout)
+	fileStorage := file.NewStorageServer(file.StorageServerArgs{
+		Dir:          "data",
+		ChunkSize:    storageChunkSize,
+		Waiter:       waiter,
+		Notifier:     notifier,
+		Class:        "rendered",
+		DebugLogger:  storageLogger,
+		CacheTimeout: storageCacheTimeout,
+		WalkTimeout:  storageWalkTimeout,
+	})
 
 	// Start NOTIFY/LISTEN functionality for the queue. Note that the database queue uses its
 	// own internal broadcaster so we can always remain subscribed to these notifications.

--- a/examples/cmd/markdownRenderer/store/queue_test.go
+++ b/examples/cmd/markdownRenderer/store/queue_test.go
@@ -43,7 +43,7 @@ func (s *QueueSqliteSuite) SetUpTest(c *check.C) {
 	c.Assert(err, check.IsNil)
 	s.tmp = tmp.Name()
 
-	llf := local.NewListenerProviderWithLogger(&fakeDebugLogger{})
+	llf := local.NewListenerProvider(local.ListenerProviderArgs{DebugLogger: &fakeDebugLogger{}})
 	s.store = Open(s.tmp, llf, rslog.NewDebugLogger(0))
 }
 

--- a/examples/cmd/testnotify/cmd/notify.go
+++ b/examples/cmd/testnotify/cmd/notify.go
@@ -87,7 +87,7 @@ func setup(drv string) (string, listenerfactory.ListenerFactory, *local.Listener
 	var prov *local.ListenerProvider
 	switch drv {
 	case "local":
-		prov = local.NewListenerProvider()
+		prov = local.NewListenerProvider(local.ListenerProviderArgs{})
 		fact = local.NewListenerFactory(prov)
 	case "pgx":
 		pool, err := pgxpool.Connect(context.Background(), connstr)
@@ -95,11 +95,11 @@ func setup(drv string) (string, listenerfactory.ListenerFactory, *local.Listener
 			return drv, nil, nil, fmt.Errorf("error connecting to pool: %s", err)
 		}
 		ipReporter := postgrespgx.NewPgxIPReporter(pool)
-		fact = postgrespgx.NewPgxListenerFactory(pool, debugLogger, ipReporter)
+		fact = postgrespgx.NewListenerFactory(postgrespgx.ListenerFactoryArgs{Pool: pool, DebugLogger: debugLogger, IpReporter: ipReporter})
 	case "pq":
 		drv = "postgres"
 		pqListenerFactory := &pqlistener{ConnStr: connstr}
-		fact = postgrespq.NewPqListenerFactory(pqListenerFactory, debugLogger)
+		fact = postgrespq.NewListenerFactory(postgrespq.ListenerFactoryArgs{Factory: pqListenerFactory, DebugLogger: debugLogger})
 	default:
 		return drv, nil, nil, fmt.Errorf("invalid --driver argument value")
 	}

--- a/pkg/rsnotify/listeners/local/factory_test.go
+++ b/pkg/rsnotify/listeners/local/factory_test.go
@@ -19,7 +19,7 @@ func (f *fakeStore) GetLocalListenerFactory() *ListenerProvider {
 }
 
 func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
-	llf := NewListenerProvider()
+	llf := NewListenerProvider(ListenerProviderArgs{})
 	cstore := &fakeStore{
 		llf: llf,
 	}

--- a/pkg/rsnotify/listeners/local/locallistener.go
+++ b/pkg/rsnotify/listeners/local/locallistener.go
@@ -34,18 +34,18 @@ type ListenerProvider struct {
 	notifyTimeout time.Duration
 }
 
-func NewListenerProvider() *ListenerProvider {
-	return NewListenerProviderWithLogger(nil)
+type ListenerProviderArgs struct {
+	DebugLogger listener.DebugLogger
 }
 
-func NewListenerProviderWithLogger(debugLogger listener.DebugLogger) *ListenerProvider {
+func NewListenerProvider(args ListenerProviderArgs) *ListenerProvider {
 	return &ListenerProvider{
 		listeners: make(map[string]*Listener),
 		mutex:     &sync.RWMutex{},
 
 		notifyTimeout: 500 * time.Millisecond,
 
-		debugLogger: debugLogger,
+		debugLogger: args.DebugLogger,
 	}
 }
 

--- a/pkg/rsnotify/listeners/local/locallistener_test.go
+++ b/pkg/rsnotify/listeners/local/locallistener_test.go
@@ -22,7 +22,7 @@ var _ = check.Suite(&LocalNotifySuite{})
 func TestPackage(t *testing.T) { check.TestingT(t) }
 
 func (s *LocalNotifySuite) TestNewLocalListener(c *check.C) {
-	f := NewListenerProvider()
+	f := NewListenerProvider(ListenerProviderArgs{})
 	l := f.New("test-a")
 	c.Check(l.guid, check.HasLen, 36)
 	l.guid = ""
@@ -35,7 +35,7 @@ func (s *LocalNotifySuite) TestNewLocalListener(c *check.C) {
 func (s *LocalNotifySuite) TestNotifications(c *check.C) {
 	defer leaktest.Check(c)()
 
-	f := NewListenerProvider()
+	f := NewListenerProvider(ListenerProviderArgs{})
 	l := f.New("test-a")
 
 	tn := listener.TestNotification{
@@ -159,7 +159,7 @@ func (s *LocalNotifySuite) TestNotifications(c *check.C) {
 func (s *LocalNotifySuite) TestNotificationsBlock(c *check.C) {
 	defer leaktest.Check(c)()
 
-	f := NewListenerProvider()
+	f := NewListenerProvider(ListenerProviderArgs{})
 	l := f.New("test-a")
 
 	tn := listener.TestNotification{
@@ -222,7 +222,7 @@ func (s *LocalNotifySuite) TestNotificationsBlock(c *check.C) {
 func (s *LocalNotifySuite) TestNotificationsErrs(c *check.C) {
 	defer leaktest.Check(c)()
 
-	f := NewListenerProvider()
+	f := NewListenerProvider(ListenerProviderArgs{})
 	l := f.New("test-a")
 
 	tn := listener.TestNotification{
@@ -294,7 +294,7 @@ func (s *LocalNotifySuite) TestNotificationsDeadlockOnClose(c *check.C) {
 	// we stop listening, a deadlock can occur. This test was introduced to
 	// catch the deadlock and ensure that we don't regress.
 
-	f := NewListenerProvider()
+	f := NewListenerProvider(ListenerProviderArgs{})
 	// Shorten timeout
 	f.notifyTimeout = 50 * time.Millisecond
 	l := f.New("test-deadlock")

--- a/pkg/rsnotify/listeners/postgrespgx/factory.go
+++ b/pkg/rsnotify/listeners/postgrespgx/factory.go
@@ -9,32 +9,44 @@ import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerutils"
 )
 
-type PgxListenerFactory struct {
+type ListenerFactory struct {
 	pool        *pgxpool.Pool
 	debugLogger listener.DebugLogger
 	listeners   []*PgxListener
 	ipReporter  listener.IPReporter
 }
 
-func NewPgxListenerFactory(pool *pgxpool.Pool, debugLogger listener.DebugLogger, iprep listener.IPReporter) *PgxListenerFactory {
-	return &PgxListenerFactory{
-		pool:        pool,
-		debugLogger: debugLogger,
-		ipReporter:  iprep,
+type ListenerFactoryArgs struct {
+	Pool        *pgxpool.Pool
+	DebugLogger listener.DebugLogger
+	IpReporter  listener.IPReporter
+}
+
+func NewListenerFactory(args ListenerFactoryArgs) *ListenerFactory {
+	return &ListenerFactory{
+		pool:        args.Pool,
+		debugLogger: args.DebugLogger,
+		ipReporter:  args.IpReporter,
 	}
 }
 
-func (l *PgxListenerFactory) Shutdown() {
+func (l *ListenerFactory) Shutdown() {
 	for _, ll := range l.listeners {
 		ll.Stop()
 	}
 }
 
-func (l *PgxListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
+func (l *ListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	pgxListener := NewPgxListener(channelName, l.pool, matcher, l.debugLogger, l.ipReporter)
+	pgxListener := NewPgxListener(PgxListenerArgs{
+		Name:        channelName,
+		Pool:        l.pool,
+		Matcher:     matcher,
+		DebugLogger: l.debugLogger,
+		IpReporter:  l.ipReporter,
+	})
 	l.listeners = append(l.listeners, pgxListener)
 	return pgxListener
 }

--- a/pkg/rsnotify/listeners/postgrespgx/factory_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/factory_test.go
@@ -18,8 +18,8 @@ func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	lgr := &listener.TestLogger{}
 	ipRep := &listener.TestIPReporter{}
 
-	l2 := NewPgxListenerFactory(pool, lgr, ipRep)
-	c.Check(l2, check.DeepEquals, &PgxListenerFactory{
+	l2 := NewListenerFactory(ListenerFactoryArgs{Pool: pool, DebugLogger: lgr, IpReporter: ipRep})
+	c.Check(l2, check.DeepEquals, &ListenerFactory{
 		pool:        pool,
 		debugLogger: lgr,
 		ipReporter:  ipRep,

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -63,15 +63,23 @@ type PgxListener struct {
 	ipReporter  listener.IPReporter
 }
 
+type PgxListenerArgs struct {
+	Name        string
+	Pool        *pgxpool.Pool
+	Matcher     listener.TypeMatcher
+	DebugLogger listener.DebugLogger
+	IpReporter  listener.IPReporter
+}
+
 // NewPgxListener creates a new listener.
 // Only intended to be called from a listener factory's `New` method.
-func NewPgxListener(name string, pool *pgxpool.Pool, matcher listener.TypeMatcher, debugLogger listener.DebugLogger, iprep listener.IPReporter) *PgxListener {
+func NewPgxListener(args PgxListenerArgs) *PgxListener {
 	return &PgxListener{
-		name:        name,
-		pool:        pool,
-		debugLogger: debugLogger,
-		matcher:     matcher,
-		ipReporter:  iprep,
+		name:        args.Name,
+		pool:        args.Pool,
+		debugLogger: args.DebugLogger,
+		matcher:     args.Matcher,
+		ipReporter:  args.IpReporter,
 	}
 }
 

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
@@ -57,7 +57,13 @@ func (s *PgxNotifySuite) TestNewPgxListener(c *check.C) {
 	lgr := &listener.TestLogger{}
 	chName := listenerutils.SafeChannelName(c.TestName())
 	ipRep := &listener.TestIPReporter{}
-	l := NewPgxListener(chName, s.pool, matcher, lgr, ipRep)
+	l := NewPgxListener(PgxListenerArgs{
+		Name:        chName,
+		Pool:        s.pool,
+		Matcher:     matcher,
+		DebugLogger: lgr,
+		IpReporter:  ipRep,
+	})
 	c.Check(l, check.DeepEquals, &PgxListener{
 		name:        chName,
 		pool:        s.pool,
@@ -93,7 +99,12 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 	ipRep := &listener.TestIPReporter{
 		Ip: "0.0.0.0",
 	}
-	l := NewPgxListener(chName, s.pool, matcher, nil, ipRep)
+	l := NewPgxListener(PgxListenerArgs{
+		Name:       chName,
+		Pool:       s.pool,
+		Matcher:    matcher,
+		IpReporter: ipRep,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -222,7 +233,12 @@ func (s *PgxNotifySuite) TestNotificationsErrors(c *check.C) {
 
 	chName := listenerutils.SafeChannelName(c.TestName())
 	ipRep := &listener.TestIPReporter{}
-	l := NewPgxListener(chName, s.pool, matcher, nil, ipRep)
+	l := NewPgxListener(PgxListenerArgs{
+		Name:       chName,
+		Pool:       s.pool,
+		Matcher:    matcher,
+		IpReporter: ipRep,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -284,7 +300,12 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 
 	chName := listenerutils.SafeChannelName(c.TestName())
 	ipRep := &listener.TestIPReporter{}
-	l := NewPgxListener(chName, s.pool, matcher, nil, ipRep)
+	l := NewPgxListener(PgxListenerArgs{
+		Name:       chName,
+		Pool:       s.pool,
+		Matcher:    matcher,
+		IpReporter: ipRep,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()

--- a/pkg/rsnotify/listeners/postgrespq/factory.go
+++ b/pkg/rsnotify/listeners/postgrespq/factory.go
@@ -7,30 +7,40 @@ import (
 	"github.com/rstudio/platform-lib/pkg/rsnotify/listenerutils"
 )
 
-type PqListenerFactory struct {
+type ListenerFactory struct {
 	factory     PqRetrieveListenerFactory
 	debugLogger listener.DebugLogger
 	listeners   []*PqListener
 }
 
-func NewPqListenerFactory(factory PqRetrieveListenerFactory, debugLogger listener.DebugLogger) *PqListenerFactory {
-	return &PqListenerFactory{
-		factory:     factory,
-		debugLogger: debugLogger,
+type ListenerFactoryArgs struct {
+	Factory     PqRetrieveListenerFactory
+	DebugLogger listener.DebugLogger
+}
+
+func NewListenerFactory(args ListenerFactoryArgs) *ListenerFactory {
+	return &ListenerFactory{
+		factory:     args.Factory,
+		debugLogger: args.DebugLogger,
 	}
 }
 
-func (l *PqListenerFactory) Shutdown() {
+func (l *ListenerFactory) Shutdown() {
 	for _, listener := range l.listeners {
 		listener.Stop()
 	}
 }
 
-func (l *PqListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
+func (l *ListenerFactory) New(channelName string, matcher listener.TypeMatcher) listener.Listener {
 	// Ensure that the channel name is safe for PostgreSQL
 	channelName = listenerutils.SafeChannelName(channelName)
 
-	listener := NewPqListener(channelName, l.factory, matcher, l.debugLogger)
+	listener := NewPqListener(PqListenerArgs{
+		Name:        channelName,
+		Factory:     l.factory,
+		Matcher:     matcher,
+		DebugLogger: l.debugLogger,
+	})
 	l.listeners = append(l.listeners, listener)
 	return listener
 }

--- a/pkg/rsnotify/listeners/postgrespq/factory_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/factory_test.go
@@ -15,8 +15,11 @@ var _ = check.Suite(&ListenerFactorySuite{})
 func (s *ListenerFactorySuite) TestNewListener(c *check.C) {
 	lgr := &listener.TestLogger{}
 	fakeFactory := &testFactory{}
-	l3 := NewPqListenerFactory(fakeFactory, lgr)
-	c.Check(l3, check.DeepEquals, &PqListenerFactory{
+	l3 := NewListenerFactory(ListenerFactoryArgs{
+		Factory:     fakeFactory,
+		DebugLogger: lgr,
+	})
+	c.Check(l3, check.DeepEquals, &ListenerFactory{
 		factory:     fakeFactory,
 		debugLogger: lgr,
 	})

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -31,13 +31,20 @@ type PqListener struct {
 	debugLogger listener.DebugLogger
 }
 
+type PqListenerArgs struct {
+	Name        string
+	Factory     PqRetrieveListenerFactory
+	Matcher     listener.TypeMatcher
+	DebugLogger listener.DebugLogger
+}
+
 // Only intended to be called from listenerfactory.go's `New` method.
-func NewPqListener(name string, factory PqRetrieveListenerFactory, matcher listener.TypeMatcher, debugLogger listener.DebugLogger) *PqListener {
+func NewPqListener(args PqListenerArgs) *PqListener {
 	return &PqListener{
-		name:        name,
-		factory:     factory,
-		debugLogger: debugLogger,
-		matcher:     matcher,
+		name:        args.Name,
+		factory:     args.Factory,
+		debugLogger: args.DebugLogger,
+		matcher:     args.Matcher,
 	}
 }
 

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
@@ -81,7 +81,12 @@ func (s *PqNotifySuite) TestNewPqListener(c *check.C) {
 	matcher.Register(2, &testNotification{})
 	lgr := &listener.TestLogger{}
 	chName := c.TestName()
-	l := NewPqListener(chName, s.factory, matcher, lgr)
+	l := NewPqListener(PqListenerArgs{
+		Name:        chName,
+		Factory:     s.factory,
+		Matcher:     matcher,
+		DebugLogger: lgr,
+	})
 	c.Check(l, check.DeepEquals, &PqListener{
 		name:        chName,
 		factory:     s.factory,
@@ -103,7 +108,11 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 	}
 
 	chName := c.TestName()
-	l := NewPqListener(chName, s.factory, matcher, nil)
+	l := NewPqListener(PqListenerArgs{
+		Name:    chName,
+		Factory: s.factory,
+		Matcher: matcher,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -231,7 +240,11 @@ func (s *PqNotifySuite) TestNotificationsErrors(c *check.C) {
 	tnBytesCannotUnmarshal := `{"NotifyType":2,"Val":{"is":"unexpected_object"}}`
 
 	chName := c.TestName()
-	l := NewPqListener(chName, s.factory, matcher, nil)
+	l := NewPqListener(PqListenerArgs{
+		Name:    chName,
+		Factory: s.factory,
+		Matcher: matcher,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()
@@ -292,7 +305,11 @@ func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
 	}
 
 	chName := c.TestName()
-	l := NewPqListener(chName, s.factory, matcher, nil)
+	l := NewPqListener(PqListenerArgs{
+		Name:    chName,
+		Factory: s.factory,
+		Matcher: matcher,
+	})
 
 	// Listen for notifications
 	data, errs, err := l.Listen()

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -158,14 +158,48 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 	}
 
 	debugLogger := &servertest.TestLogger{}
-	pgServer := postgres.NewPgStorageServer(class, 100*1024, wn, wn, s.pool, debugLogger)
-	s3Server := s3server.NewS3StorageServer(class, "", s3Svc, 100*1024, wn, wn)
-	fileServer := file.NewFileStorageServer(dir, 100*1024, wn, wn, class, debugLogger, time.Minute, time.Minute)
+	pgServer := postgres.NewStorageServer(postgres.StorageServerArgs{
+		ChunkSize:   100 * 1024,
+		Waiter:      wn,
+		Notifier:    wn,
+		Class:       class,
+		DebugLogger: debugLogger,
+		Pool:        s.pool,
+	})
+	s3Server := s3server.NewStorageServer(s3server.StorageServerArgs{
+		Bucket:    class,
+		Svc:       s3Svc,
+		ChunkSize: 100 * 1024,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
+	fileServer := file.NewStorageServer(file.StorageServerArgs{
+		Dir:          dir,
+		ChunkSize:    100 * 1024,
+		Waiter:       wn,
+		Notifier:     wn,
+		Class:        class,
+		DebugLogger:  debugLogger,
+		CacheTimeout: time.Minute,
+		WalkTimeout:  time.Minute,
+	})
 
 	return map[string]rsstorage.StorageServer{
-		"file":     rsstorage.NewMetadataStorageServer("file", fileServer, cstore),
-		"s3":       rsstorage.NewMetadataStorageServer("s3", s3Server, cstore),
-		"postgres": rsstorage.NewMetadataStorageServer("pg", pgServer, cstore),
+		"file": rsstorage.NewMetadataStorageServer(rsstorage.MetadataStorageServerArgs{
+			Name:   "file",
+			Server: fileServer,
+			Store:  cstore,
+		}),
+		"s3": rsstorage.NewMetadataStorageServer(rsstorage.MetadataStorageServerArgs{
+			Name:   "s3",
+			Server: s3Server,
+			Store:  cstore,
+		}),
+		"postgres": rsstorage.NewMetadataStorageServer(rsstorage.MetadataStorageServerArgs{
+			Name:   "pg",
+			Server: pgServer,
+			Store:  cstore,
+		}),
 	}
 }
 
@@ -436,7 +470,14 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHang(c *check.C) {
 	wn := &servertest.DummyWaiterNotifier{
 		Ch: make(chan bool, 1),
 	}
-	s3Server := s3server.NewS3StorageServer(bucket, "integration-test", s3Svc, 100*1024, wn, wn)
+	s3Server := s3server.NewStorageServer(s3server.StorageServerArgs{
+		Bucket:    bucket,
+		Prefix:    "integration-test",
+		Svc:       s3Svc,
+		ChunkSize: 100 * 1024,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 
 	// This channel gets notified/closed after we start writing some data to the writer,
 	// but before the write fails.
@@ -561,7 +602,14 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHangChunked(c *check.C) {
 	wn := &servertest.DummyWaiterNotifier{
 		Ch: make(chan bool, 1),
 	}
-	s3Server := s3server.NewS3StorageServer(bucket, "integration-test", s3Svc, 100*1024, wn, wn)
+	s3Server := s3server.NewStorageServer(s3server.StorageServerArgs{
+		Bucket:    bucket,
+		Prefix:    "integration-test",
+		Svc:       s3Svc,
+		ChunkSize: 100 * 1024,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 
 	// This channel gets notified/closed after we start writing some data to the writer,
 	// but before the write fails.

--- a/pkg/rsstorage/server_metadata.go
+++ b/pkg/rsstorage/server_metadata.go
@@ -17,11 +17,17 @@ type MetadataStorageServer struct {
 	name  string
 }
 
-func NewMetadataStorageServer(name string, server StorageServer, store CacheStore) StorageServer {
+type MetadataStorageServerArgs struct {
+	Name   string
+	Server StorageServer
+	Store  CacheStore
+}
+
+func NewMetadataStorageServer(args MetadataStorageServerArgs) StorageServer {
 	return &MetadataStorageServer{
-		StorageServer: server,
-		name:          name,
-		store:         store,
+		StorageServer: args.Server,
+		name:          args.Name,
+		store:         args.Store,
 	}
 }
 

--- a/pkg/rsstorage/server_metadata_test.go
+++ b/pkg/rsstorage/server_metadata_test.go
@@ -72,7 +72,11 @@ func (s *cacheStore) CacheObjectMarkUse(cacheName, key string, accessTime time.T
 func (s *MetadataServerSuite) TestNew(c *check.C) {
 	parentServer := &DummyStorageServer{}
 	cstore := &cacheStore{}
-	server := NewMetadataStorageServer("test", parentServer, cstore)
+	server := NewMetadataStorageServer(MetadataStorageServerArgs{
+		Name:   "test",
+		Server: parentServer,
+		Store:  cstore,
+	})
 	c.Check(server, check.DeepEquals, &MetadataStorageServer{
 		StorageServer: parentServer,
 		name:          "test",

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -42,30 +42,41 @@ type StorageServer struct {
 	debugLogger  rsstorage.DebugLogger
 }
 
-func NewFileStorageServer(dir string, chunkSize uint64, waiter rsstorage.ChunkWaiter, notifier rsstorage.ChunkNotifier, class string, debugLogger rsstorage.DebugLogger, cacheTimeout, walkTimeout time.Duration) rsstorage.StorageServer {
+type StorageServerArgs struct {
+	Dir          string
+	ChunkSize    uint64
+	Waiter       rsstorage.ChunkWaiter
+	Notifier     rsstorage.ChunkNotifier
+	Class        string
+	DebugLogger  rsstorage.DebugLogger
+	CacheTimeout time.Duration
+	WalkTimeout  time.Duration
+}
+
+func NewStorageServer(args StorageServerArgs) rsstorage.StorageServer {
 	fs := &StorageServer{
-		dir:          dir,
+		dir:          args.Dir,
 		fileIO:       &defaultFileIO{},
-		class:        class,
-		debugLogger:  debugLogger,
-		cacheTimeout: cacheTimeout,
-		walkTimeout:  walkTimeout,
+		class:        args.Class,
+		debugLogger:  args.DebugLogger,
+		cacheTimeout: args.CacheTimeout,
+		walkTimeout:  args.WalkTimeout,
 	}
 	return &StorageServer{
-		dir:          dir,
+		dir:          args.Dir,
 		fileIO:       &defaultFileIO{},
-		debugLogger:  debugLogger,
-		cacheTimeout: cacheTimeout,
-		walkTimeout:  walkTimeout,
+		debugLogger:  args.DebugLogger,
+		cacheTimeout: args.CacheTimeout,
+		walkTimeout:  args.WalkTimeout,
 		chunker: &internal.DefaultChunkUtils{
-			ChunkSize:   chunkSize,
+			ChunkSize:   args.ChunkSize,
 			Server:      fs,
-			Waiter:      waiter,
-			Notifier:    notifier,
+			Waiter:      args.Waiter,
+			Notifier:    args.Notifier,
 			PollTimeout: rsstorage.DefaultChunkPollTimeout,
 			MaxAttempts: rsstorage.DefaultMaxChunkAttempts,
 		},
-		class: class,
+		class: args.Class,
 	}
 }
 

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -53,7 +53,16 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 		Ch: make(chan bool, 1),
 	}
 	debugLogger := &servertest.TestLogger{}
-	server := NewFileStorageServer("test", 4096, wn, wn, "classname", debugLogger, time.Minute, time.Minute)
+	server := NewStorageServer(StorageServerArgs{
+		Dir:          "test",
+		ChunkSize:    4096,
+		Waiter:       wn,
+		Notifier:     wn,
+		Class:        "classname",
+		DebugLogger:  debugLogger,
+		CacheTimeout: time.Minute,
+		WalkTimeout:  time.Minute * 2,
+	})
 
 	c.Check(server, check.DeepEquals, &StorageServer{
 		dir:    "test",
@@ -64,7 +73,7 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 				dir:          "test",
 				fileIO:       &defaultFileIO{},
 				cacheTimeout: time.Minute,
-				walkTimeout:  time.Minute,
+				walkTimeout:  time.Minute * 2,
 				class:        "classname",
 				debugLogger:  debugLogger,
 			},
@@ -74,7 +83,7 @@ func (s *FileStorageServerSuite) TestNew(c *check.C) {
 			MaxAttempts: rsstorage.DefaultMaxChunkAttempts,
 		},
 		cacheTimeout: time.Minute,
-		walkTimeout:  time.Minute,
+		walkTimeout:  time.Minute * 2,
 		class:        "classname",
 		debugLogger:  debugLogger,
 	})

--- a/pkg/rsstorage/servers/postgres/server.go
+++ b/pkg/rsstorage/servers/postgres/server.go
@@ -29,21 +29,30 @@ type StorageServer struct {
 	debugLogger rsstorage.DebugLogger
 }
 
-func NewPgStorageServer(class string, chunkSize uint64, waiter rsstorage.ChunkWaiter, notifier rsstorage.ChunkNotifier, pool *pgxpool.Pool, debugLogger rsstorage.DebugLogger) rsstorage.StorageServer {
+type StorageServerArgs struct {
+	ChunkSize   uint64
+	Waiter      rsstorage.ChunkWaiter
+	Notifier    rsstorage.ChunkNotifier
+	Class       string
+	DebugLogger rsstorage.DebugLogger
+	Pool        *pgxpool.Pool
+}
+
+func NewStorageServer(args StorageServerArgs) rsstorage.StorageServer {
 	pgs := &StorageServer{
-		class:       class,
-		pool:        pool,
-		debugLogger: debugLogger,
+		class:       args.Class,
+		pool:        args.Pool,
+		debugLogger: args.DebugLogger,
 	}
 	return &StorageServer{
-		class:       class,
-		pool:        pool,
-		debugLogger: debugLogger,
+		class:       args.Class,
+		pool:        args.Pool,
+		debugLogger: args.DebugLogger,
 		chunker: &internal.DefaultChunkUtils{
-			ChunkSize:   chunkSize,
+			ChunkSize:   args.ChunkSize,
 			Server:      pgs,
-			Waiter:      waiter,
-			Notifier:    notifier,
+			Waiter:      args.Waiter,
+			Notifier:    args.Notifier,
 			PollTimeout: rsstorage.DefaultChunkPollTimeout,
 			MaxAttempts: rsstorage.DefaultMaxChunkAttempts,
 		},

--- a/pkg/rsstorage/servers/postgres/server_test.go
+++ b/pkg/rsstorage/servers/postgres/server_test.go
@@ -52,7 +52,14 @@ func (s *PgCacheServerSuite) SetUpTest(c *check.C) {
 func (s *PgCacheServerSuite) TestNew(c *check.C) {
 	wn := &servertest.DummyWaiterNotifier{}
 	debugLogger := &servertest.TestLogger{}
-	server := NewPgStorageServer("test", 100*1024, wn, wn, s.pool, debugLogger)
+	server := NewStorageServer(StorageServerArgs{
+		ChunkSize:   100 * 1024,
+		Waiter:      wn,
+		Notifier:    wn,
+		Class:       "test",
+		DebugLogger: debugLogger,
+		Pool:        s.pool,
+	})
 	c.Check(server.(*StorageServer).chunker, check.NotNil)
 	server.(*StorageServer).chunker = nil
 	c.Check(server, check.DeepEquals, &StorageServer{
@@ -713,7 +720,13 @@ func (s *PgCacheServerSuite) TestLocate(c *check.C) {
 func (s *PgCacheServerSuite) TestUsage(c *check.C) {
 	wn := &servertest.DummyWaiterNotifier{}
 	debugLogger := &servertest.TestLogger{}
-	server := NewPgStorageServer("testclass", 100*1024, wn, wn, nil, debugLogger)
+	server := NewStorageServer(StorageServerArgs{
+		ChunkSize:   100 * 1024,
+		Waiter:      wn,
+		Notifier:    wn,
+		Class:       "testclass",
+		DebugLogger: debugLogger,
+	})
 
 	c.Assert(server.Dir(), check.Equals, "pg:testclass")
 	c.Assert(server.Type(), check.Equals, rsstorage.StorageTypePostgres)

--- a/pkg/rsstorage/servers/s3server/s3_service_test.go
+++ b/pkg/rsstorage/servers/s3server/s3_service_test.go
@@ -239,7 +239,14 @@ func (s *S3WrapperSuite) TestSetStorageS3Validate(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	wn := &servertest.DummyWaiterNotifier{}
-	s3srv := NewS3StorageServer("packages", "s3", svc, 4096, wn, wn)
+	s3srv := NewStorageServer(StorageServerArgs{
+		Bucket:    "packages",
+		Prefix:    "s3",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 
 	err = s3srv.(*StorageServer).Validate()
 	c.Assert(err, check.NotNil)

--- a/pkg/rsstorage/servers/s3server/server.go
+++ b/pkg/rsstorage/servers/s3server/server.go
@@ -34,25 +34,34 @@ type StorageServer struct {
 	chunker rsstorage.ChunkUtils
 }
 
-func NewS3StorageServer(bucket, prefix string, svc S3Wrapper, chunkSize uint64, waiter rsstorage.ChunkWaiter, notifier rsstorage.ChunkNotifier) rsstorage.StorageServer {
+type StorageServerArgs struct {
+	Bucket    string
+	Prefix    string
+	Svc       S3Wrapper
+	ChunkSize uint64
+	Waiter    rsstorage.ChunkWaiter
+	Notifier  rsstorage.ChunkNotifier
+}
+
+func NewStorageServer(args StorageServerArgs) rsstorage.StorageServer {
 	s3s := &StorageServer{
-		bucket: bucket,
-		prefix: prefix,
-		svc:    svc,
-		move:   svc.MoveObject,
-		copy:   svc.CopyObject,
+		bucket: args.Bucket,
+		prefix: args.Prefix,
+		svc:    args.Svc,
+		move:   args.Svc.MoveObject,
+		copy:   args.Svc.CopyObject,
 	}
 	return &StorageServer{
-		bucket: bucket,
-		prefix: prefix,
-		svc:    svc,
-		move:   svc.MoveObject,
-		copy:   svc.CopyObject,
+		bucket: args.Bucket,
+		prefix: args.Prefix,
+		svc:    args.Svc,
+		move:   args.Svc.MoveObject,
+		copy:   args.Svc.CopyObject,
 		chunker: &internal.DefaultChunkUtils{
-			ChunkSize:   chunkSize,
+			ChunkSize:   args.ChunkSize,
 			Server:      s3s,
-			Waiter:      waiter,
-			Notifier:    notifier,
+			Waiter:      args.Waiter,
+			Notifier:    args.Notifier,
 			PollTimeout: rsstorage.DefaultChunkPollTimeout,
 			MaxAttempts: rsstorage.DefaultMaxChunkAttempts,
 		},

--- a/pkg/rsstorage/servers/s3server/server_test.go
+++ b/pkg/rsstorage/servers/s3server/server_test.go
@@ -164,7 +164,14 @@ func (s *fakeS3) Upload(input *s3manager.UploadInput, ctx context.Context, optio
 func (s *S3StorageServerSuite) TestNew(c *check.C) {
 	svc := &fakeS3{}
 	wn := &servertest.DummyWaiterNotifier{}
-	server := NewS3StorageServer("test", "prefix", svc, 4096, wn, wn)
+	server := NewStorageServer(StorageServerArgs{
+		Bucket:    "test",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 	c.Assert(server.(*StorageServer).move, check.NotNil)
 	c.Assert(server.(*StorageServer).copy, check.NotNil)
 	c.Assert(server.(*StorageServer).chunker, check.NotNil)
@@ -955,7 +962,14 @@ func (s *S3StorageServerSuite) TestLocate(c *check.C) {
 func (s *S3StorageServerSuite) TestUsage(c *check.C) {
 	svc := &fakeS3{}
 	wn := &servertest.DummyWaiterNotifier{}
-	server := NewS3StorageServer("testbucket", "prefix", svc, 4096, wn, wn)
+	server := NewStorageServer(StorageServerArgs{
+		Bucket:    "testbucket",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 
 	usage, err := server.CalculateUsage()
 	c.Assert(usage, check.DeepEquals, types.Usage{})
@@ -969,7 +983,14 @@ func (s *S3StorageServerSuite) TestValidate(c *check.C) {
 
 	svc := &fakeS3{}
 	wn := &servertest.DummyWaiterNotifier{}
-	server := NewS3StorageServer("testbucket", "prefix", svc, 4096, wn, wn)
+	server := NewStorageServer(StorageServerArgs{
+		Bucket:    "testbucket",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 
 	s3, ok := server.(*StorageServer)
 	c.Assert(ok, check.Equals, true)
@@ -980,7 +1001,14 @@ func (s *S3StorageServerSuite) TestValidate(c *check.C) {
 	svc = &fakeS3{
 		uploadErr: uploadErr,
 	}
-	server = NewS3StorageServer("testbucket", "prefix", svc, 4096, wn, wn)
+	server = NewStorageServer(StorageServerArgs{
+		Bucket:    "testbucket",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 	s3, ok = server.(*StorageServer)
 	c.Assert(ok, check.Equals, true)
 	err = s3.Validate()
@@ -989,7 +1017,14 @@ func (s *S3StorageServerSuite) TestValidate(c *check.C) {
 	svc = &fakeS3{
 		headErr: headErr,
 	}
-	server = NewS3StorageServer("testbucket", "prefix", svc, 4096, wn, wn)
+	server = NewStorageServer(StorageServerArgs{
+		Bucket:    "testbucket",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 	s3, ok = server.(*StorageServer)
 	c.Assert(ok, check.Equals, true)
 	err = s3.Validate()
@@ -998,7 +1033,14 @@ func (s *S3StorageServerSuite) TestValidate(c *check.C) {
 	svc = &fakeS3{
 		headErr: deleteErr,
 	}
-	server = NewS3StorageServer("testbucket", "prefix", svc, 4096, wn, wn)
+	server = NewStorageServer(StorageServerArgs{
+		Bucket:    "testbucket",
+		Prefix:    "prefix",
+		Svc:       svc,
+		ChunkSize: 4096,
+		Waiter:    wn,
+		Notifier:  wn,
+	})
 	s3, ok = server.(*StorageServer)
 	c.Assert(ok, check.Equals, true)
 	err = s3.Validate()


### PR DESCRIPTION
Tweaks the rsnotify and rsstorage packages to accept arg structs for the `New*` methods for better method signature compatibility going forward.