### PR TITLE
Change Type() signature to return interface and error

### DIFF
--- a/pkg/rsnotify/listener/genericmatcher.go
+++ b/pkg/rsnotify/listener/genericmatcher.go
@@ -1,5 +1,7 @@
 package listener
 
+// Copyright (C) 2022 by RStudio, PBC.
+
 import (
 	"errors"
 	"fmt"

--- a/pkg/rsnotify/listener/genericmatcher.go
+++ b/pkg/rsnotify/listener/genericmatcher.go
@@ -1,0 +1,27 @@
+package listener
+
+// Copyright (C) 2022 by RStudio, PBC.
+
+type GenericMatcher struct {
+	field string
+	types map[uint8]interface{}
+}
+
+func (m *GenericMatcher) Field() string {
+	return m.field
+}
+
+func (m *GenericMatcher) Type(notifyType uint8) (interface{}, error) {
+	return m.types[notifyType], nil
+}
+
+func (m *GenericMatcher) Register(notifyType uint8, dataType interface{}) {
+	m.types[notifyType] = dataType
+}
+
+func NewMatcher(field string) *GenericMatcher {
+	return &GenericMatcher{
+		field: field,
+		types: make(map[uint8]interface{}),
+	}
+}

--- a/pkg/rsnotify/listener/genericmatcher.go
+++ b/pkg/rsnotify/listener/genericmatcher.go
@@ -1,6 +1,12 @@
 package listener
 
+import (
+	"errors"
+)
+
 // Copyright (C) 2022 by RStudio, PBC.
+
+var MissingTypeError = errors.New("MissingType error")
 
 type GenericMatcher struct {
 	field string
@@ -12,7 +18,10 @@ func (m *GenericMatcher) Field() string {
 }
 
 func (m *GenericMatcher) Type(notifyType uint8) (interface{}, error) {
-	return m.types[notifyType], nil
+	if t, ok := m.types[notifyType]; ok {
+		return t, nil
+	}
+	return nil, MissingTypeError
 }
 
 func (m *GenericMatcher) Register(notifyType uint8, dataType interface{}) {

--- a/pkg/rsnotify/listener/genericmatcher.go
+++ b/pkg/rsnotify/listener/genericmatcher.go
@@ -2,6 +2,7 @@ package listener
 
 import (
 	"errors"
+	"fmt"
 )
 
 // Copyright (C) 2022 by RStudio, PBC.
@@ -21,7 +22,7 @@ func (m *GenericMatcher) Type(notifyType uint8) (interface{}, error) {
 	if t, ok := m.types[notifyType]; ok {
 		return t, nil
 	}
-	return nil, MissingTypeError
+	return nil, fmt.Errorf("no matcher type found for %d: %w", notifyType, MissingTypeError)
 }
 
 func (m *GenericMatcher) Register(notifyType uint8, dataType interface{}) {

--- a/pkg/rsnotify/listener/genericmatcher_test.go
+++ b/pkg/rsnotify/listener/genericmatcher_test.go
@@ -3,6 +3,8 @@ package listener
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
+	"fmt"
+
 	"gopkg.in/check.v1"
 )
 
@@ -60,7 +62,9 @@ func (s *GenericMatcherSuite) TestType(c *check.C) {
 }
 
 func (s *GenericMatcherSuite) TestUnknownType(c *check.C) {
+	const missingNotificationType = 0
 	const testNotificationType = 1
+	expectedErr := fmt.Errorf("no matcher type found for %d: %w", missingNotificationType, MissingTypeError)
 	type TestNotification struct{}
 	m := &GenericMatcher{
 		field: "test",
@@ -69,8 +73,8 @@ func (s *GenericMatcherSuite) TestUnknownType(c *check.C) {
 	m.Register(testNotificationType, TestNotification{})
 	c.Assert(m.types[testNotificationType], check.NotNil)
 
-	t, err := m.Type(0)
+	t, err := m.Type(missingNotificationType)
 	c.Assert(err, check.NotNil)
-	c.Assert(err, check.Equals, MissingTypeError)
+	c.Assert(err, check.DeepEquals, expectedErr)
 	c.Assert(t, check.IsNil)
 }

--- a/pkg/rsnotify/listener/genericmatcher_test.go
+++ b/pkg/rsnotify/listener/genericmatcher_test.go
@@ -1,0 +1,59 @@
+package listener
+
+// Copyright (C) 2022 by RStudio, PBC.
+
+import (
+	"gopkg.in/check.v1"
+)
+
+type GenericMatcherSuite struct{}
+
+var _ = check.Suite(&GenericMatcherSuite{})
+
+func (s *GenericMatcherSuite) TestNewMatcher(c *check.C) {
+	types := make(map[uint8]interface{})
+	m := NewMatcher("test")
+
+	c.Assert(m, check.DeepEquals, &GenericMatcher{
+		field: "test",
+		types: types,
+	})
+}
+
+func (s *GenericMatcherSuite) TestRegister(c *check.C) {
+	const testNotificationType = 1
+	type TestNotification struct{}
+	m := &GenericMatcher{
+		field: "test",
+		types: make(map[uint8]interface{}),
+	}
+	m.Register(testNotificationType, TestNotification{})
+	c.Assert(m.types[testNotificationType], check.NotNil)
+	c.Assert(len(m.types), check.Equals, 1)
+}
+
+func (s *GenericMatcherSuite) TestField(c *check.C) {
+	const testNotificationType = 1
+	const testField = "test"
+	type TestNotification struct{}
+	m := &GenericMatcher{
+		field: testField,
+		types: make(map[uint8]interface{}),
+	}
+	f := m.Field()
+	c.Assert(f, check.Equals, testField)
+}
+
+func (s *GenericMatcherSuite) TestType(c *check.C) {
+	const testNotificationType = 1
+	type TestNotification struct{}
+	m := &GenericMatcher{
+		field: "test",
+		types: make(map[uint8]interface{}),
+	}
+	m.Register(testNotificationType, TestNotification{})
+	c.Assert(m.types[testNotificationType], check.NotNil)
+
+	t, _ := m.Type(testNotificationType)
+	c.Assert(t, check.NotNil)
+}

--- a/pkg/rsnotify/listener/genericmatcher_test.go
+++ b/pkg/rsnotify/listener/genericmatcher_test.go
@@ -54,6 +54,23 @@ func (s *GenericMatcherSuite) TestType(c *check.C) {
 	m.Register(testNotificationType, TestNotification{})
 	c.Assert(m.types[testNotificationType], check.NotNil)
 
-	t, _ := m.Type(testNotificationType)
+	t, err := m.Type(testNotificationType)
+	c.Assert(err, check.IsNil)
 	c.Assert(t, check.NotNil)
+}
+
+func (s *GenericMatcherSuite) TestUnknownType(c *check.C) {
+	const testNotificationType = 1
+	type TestNotification struct{}
+	m := &GenericMatcher{
+		field: "test",
+		types: make(map[uint8]interface{}),
+	}
+	m.Register(testNotificationType, TestNotification{})
+	c.Assert(m.types[testNotificationType], check.NotNil)
+
+	t, err := m.Type(0)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.Equals, MissingTypeError)
+	c.Assert(t, check.IsNil)
 }

--- a/pkg/rsnotify/listener/listener.go
+++ b/pkg/rsnotify/listener/listener.go
@@ -46,27 +46,3 @@ func (n *GenericNotification) Type() uint8 {
 func (n *GenericNotification) Guid() string {
 	return n.NotifyGuid
 }
-
-type GenericMatcher struct {
-	field string
-	types map[uint8]interface{}
-}
-
-func (m *GenericMatcher) Field() string {
-	return m.field
-}
-
-func (m *GenericMatcher) Type(notifyType uint8) (interface{}, error) {
-	return m.types[notifyType], nil
-}
-
-func (m *GenericMatcher) Register(notifyType uint8, dataType interface{}) {
-	m.types[notifyType] = dataType
-}
-
-func NewMatcher(field string) *GenericMatcher {
-	return &GenericMatcher{
-		field: field,
-		types: make(map[uint8]interface{}),
-	}
-}

--- a/pkg/rsnotify/listener/listener.go
+++ b/pkg/rsnotify/listener/listener.go
@@ -11,7 +11,7 @@ const (
 type TypeMatcher interface {
 	Field() string
 	Register(notifyType uint8, dataType interface{})
-	Type(notifyType uint8) interface{}
+	Type(notifyType uint8) (interface{}, error)
 }
 
 type Notification interface {
@@ -56,8 +56,8 @@ func (m *GenericMatcher) Field() string {
 	return m.field
 }
 
-func (m *GenericMatcher) Type(notifyType uint8) interface{} {
-	return m.types[notifyType]
+func (m *GenericMatcher) Type(notifyType uint8) (interface{}, error) {
+	return m.types[notifyType], nil
 }
 
 func (m *GenericMatcher) Register(notifyType uint8, dataType interface{}) {

--- a/pkg/rsnotify/listener/listener_test.go
+++ b/pkg/rsnotify/listener/listener_test.go
@@ -3,13 +3,9 @@ package listener
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"testing"
-
 	"gopkg.in/check.v1"
 )
 
-type NotifySuite struct{}
+type ListenerSuite struct{}
 
-var _ = check.Suite(&NotifySuite{})
-
-func TestPackage(t *testing.T) { check.TestingT(t) }
+var _ = check.Suite(&ListenerSuite{})

--- a/pkg/rsnotify/listener/listener_test.go
+++ b/pkg/rsnotify/listener/listener_test.go
@@ -3,9 +3,13 @@ package listener
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
+	"testing"
+
 	"gopkg.in/check.v1"
 )
 
 type ListenerSuite struct{}
+
+func TestPackage(t *testing.T) { check.TestingT(t) }
 
 var _ = check.Suite(&ListenerSuite{})

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -224,13 +224,17 @@ func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan
 		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
 		return
 	}
-	if l.matcher.Type(dataType) == nil {
+	t, err := l.matcher.Type(dataType)
+	if err != nil {
+		return
+	}
+	if t == nil {
 		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 
 	// Get an object of the correct type
-	input = reflect.New(reflect.ValueOf(l.matcher.Type(dataType)).Elem().Type()).Interface().(listener.Notification)
+	input = reflect.New(reflect.ValueOf(t).Elem().Type()).Interface().(listener.Notification)
 
 	// Unmarshal the payload
 	err = json.Unmarshal(payloadBytes, input)

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -226,7 +226,7 @@ func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan
 	}
 	t, err := l.matcher.Type(dataType)
 	if err != nil {
-		errs <- fmt.Errorf("no matcher type found for %d", dataType)
+		errs <- err
 		return
 	}
 	if t == nil {

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -226,10 +226,10 @@ func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan
 	}
 	t, err := l.matcher.Type(dataType)
 	if err != nil {
+		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 	if t == nil {
-		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -185,10 +185,10 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 	}
 	t, err := l.matcher.Type(dataType)
 	if err != nil {
+		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 	if t == nil {
-		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -183,13 +183,17 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 		errs <- fmt.Errorf("error unmarshalling message data type: %s", err)
 		return
 	}
-	if l.matcher.Type(dataType) == nil {
+	t, err := l.matcher.Type(dataType)
+	if err != nil {
+		return
+	}
+	if t == nil {
 		errs <- fmt.Errorf("no matcher type found for %d", dataType)
 		return
 	}
 
 	// Get an object of the correct type
-	input = reflect.New(reflect.ValueOf(l.matcher.Type(dataType)).Elem().Type()).Interface().(listener.Notification)
+	input = reflect.New(reflect.ValueOf(t).Elem().Type()).Interface().(listener.Notification)
 
 	// Unmarshal the payload
 	err = json.Unmarshal(payloadBytes, input)

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -185,7 +185,7 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 	}
 	t, err := l.matcher.Type(dataType)
 	if err != nil {
-		errs <- fmt.Errorf("no matcher type found for %d", dataType)
+		errs <- err
 		return
 	}
 	if t == nil {

--- a/pkg/rsqueue/groups/grouprunner.go
+++ b/pkg/rsqueue/groups/grouprunner.go
@@ -132,7 +132,7 @@ func (r *QueueGroupRunner) unmarshal(work []byte) (GroupQueueJob, error) {
 	}
 	t, err := r.matcher.Type(dataType)
 	if err != nil {
-		return
+		return nil, nil
 	}
 	if t == nil {
 		return nil, fmt.Errorf("no matcher type found for %d", dataType)

--- a/pkg/rsqueue/groups/grouprunner.go
+++ b/pkg/rsqueue/groups/grouprunner.go
@@ -45,7 +45,7 @@ func (m *GenericMatcher) Type(workType uint64) (interface{}, error) {
 	if t, ok := m.types[workType]; ok {
 		return t, nil
 	}
-	return nil, MissingTypeError
+	return nil, fmt.Errorf("no matcher type found for %d: %w", workType, MissingTypeError)
 }
 
 func (m *GenericMatcher) Register(workType uint64, dataType interface{}) {
@@ -136,7 +136,7 @@ func (r *QueueGroupRunner) unmarshal(work []byte) (GroupQueueJob, error) {
 	}
 	t, err := r.matcher.Type(dataType)
 	if err != nil {
-		return nil, fmt.Errorf("no matcher type found for %d", dataType)
+		return nil, err
 	}
 	if t == nil {
 		return nil, nil

--- a/pkg/rsqueue/groups/grouprunner_test.go
+++ b/pkg/rsqueue/groups/grouprunner_test.go
@@ -269,7 +269,7 @@ func (s *QueueGroupRunnerSuite) TestUnmarshal(c *check.C) {
 	// No matcher for type
 	work = []byte(`{"type":222,"value":"a test"}`)
 	_, err = r.unmarshal(work)
-	c.Assert(err, check.ErrorMatches, "no matcher type found for 222")
+	c.Assert(err, check.ErrorMatches, "no matcher type found for 222: MissingType error")
 
 	// Job unmarshal error
 	work = []byte(`{"type":3,"value":{"json":"object"}}`)


### PR DESCRIPTION
This PR changes TypeMatcher's Type() signature to return interface and error.

This change is needed to address an [issue](https://github.com/rstudio/package-manager/issues/7714 ) where the offline node is receiving messages for queue work (work ready, work complete), but it is not configured to handle those message types. This error is innocuous, but could be alarming to customers.