### PR TITLE
'-buildvcs=false' for temporary build fix

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ vet:
 # Builds Go code natively.
 build:
     cd examples && \
-    go build -o ../out/ ./...
+    go build -buildvcs=false -o ../out/ ./...
 
 # run linters
 lint:

--- a/justfile
+++ b/justfile
@@ -60,6 +60,14 @@ lint:
     ./scripts/header-check.sh
     ./scripts/test-wiring.sh
 
+# Opens a shell in the dev docker container.
+bash:
+    docker run {{ interactive }} --rm \
+        -v {{justfile_directory()}}/:/build \
+        -e GOCACHE=/platform-lib/.go-cache \
+        -w /build \
+        rstudio/platform-lib:lib-build /bin/bash
+
 # Builds Go code using docker. Useful when using a MacOS or Windows native IDE. First,
 # run `just build-build-env' to create the docker image you'll need.
 build-docker:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,7 @@ DEF_TEST_ARGS=${DEF_TEST_ARGS:--short}
 for MODULE in ${MODULES}; do
     cd ${MODULE}
 
-    go test ${DEF_TEST_ARGS} ${TEST_ARGS[*]}
+    go test -buildvcs=false ${DEF_TEST_ARGS} ${TEST_ARGS[*]}
     result=$?
     if [[ $result -ne 0 ]]; then
       __EXITCODE=$result


### PR DESCRIPTION
Attempting to fix the build issues. This updates the GHA configuration to also use Go 1.18 (used by dockerfile), and uses the `-buildvcs=false` flag where necessary to fix the build errors. 

I think the build errors are due to older versions of Git that don't support Go's VCS stamping, so we could consider updating Git instead.