### PR TITLE
adding entry formatters that enforce UTC time conversion

### DIFF
--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -77,16 +77,49 @@ func NewLoggerImpl(options LoggerOptionsImpl,
 	}, nil
 }
 
-func getFormatter(outputFormat OutputFormat) logrus.Formatter {
-	switch outputFormat {
-	case JSONFormat:
-		return &logrus.JSONFormatter{TimestampFormat: "2006-01-02T15:04:05.000Z"}
-	default:
-		return &logrus.TextFormatter{
+//Formatters which enforce UTC timestamp representation
+
+type UTCJSONFormatter struct {
+	*logrus.JSONFormatter
+}
+
+func NewUTCJSONFormatter() *UTCJSONFormatter {
+	return &UTCJSONFormatter{
+		&logrus.JSONFormatter{
+			TimestampFormat: "2006-01-02T15:04:05.000Z",
+		},
+	}
+}
+
+func (u UTCJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	e.Time = e.Time.UTC()
+	return u.JSONFormatter.Format(e)
+}
+
+type UTCTextFormatter struct {
+	*logrus.TextFormatter
+}
+
+func NewUTCTextFormatter() *UTCTextFormatter {
+	return &UTCTextFormatter{
+		&logrus.TextFormatter{
 			FullTimestamp:          true,
 			TimestampFormat:        "2006-01-02T15:04:05.000Z",
 			DisableLevelTruncation: true,
-		}
+		}}
+}
+
+func (u UTCTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	e.Time = e.Time.UTC()
+	return u.TextFormatter.Format(e)
+}
+
+func getFormatter(outputFormat OutputFormat) logrus.Formatter {
+	switch outputFormat {
+	case JSONFormat:
+		return NewUTCJSONFormatter()
+	default:
+		return NewUTCTextFormatter()
 	}
 }
 

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -91,7 +91,7 @@ func NewUTCJSONFormatter() *UTCJSONFormatter {
 	}
 }
 
-func (u UTCJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
+func (u *UTCJSONFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Time = e.Time.UTC()
 	return u.JSONFormatter.Format(e)
 }
@@ -109,7 +109,7 @@ func NewUTCTextFormatter() *UTCTextFormatter {
 		}}
 }
 
-func (u UTCTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
+func (u *UTCTextFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	e.Time = e.Time.UTC()
 	return u.TextFormatter.Format(e)
 }

--- a/pkg/rslog/rslogtest/logger_impl_test.go
+++ b/pkg/rslog/rslogtest/logger_impl_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rstudio/platform-lib/pkg/rslog"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -356,32 +357,8 @@ func (s *LoggerImplTestSuite) TestNewDiscardingLogger() {
 }
 
 func (s *LoggerImplTestSuite) TestUTCJSONFormatter() {
-	// create a test location 1 hr east of UTC
-	loc := time.FixedZone("test/zone", 3600)
-	utc := time.Now().UTC()
 
-	// shift UTC time to the test location
-	nonUtc := utc.In(loc)
-
-	// verify shifted time is 1 hr ahead
-	expected := utc.Add(time.Hour)
-
-	expYear, expMonth, expDay := expected.Date()
-	nonUtcYear, nonUtcMonth, nonUtcDay := nonUtc.Date()
-
-	s.Equal(expYear, nonUtcYear)
-	s.Equal(expMonth, nonUtcMonth)
-	s.Equal(expDay, nonUtcDay)
-
-	expHour, expMin, expSec := expected.Clock()
-	nonUtcHour, nonUtcMin, nonUtcSec := nonUtc.Clock()
-
-	s.Equal(expHour, nonUtcHour)
-	s.Equal(expMin, nonUtcMin)
-	s.Equal(expSec, nonUtcSec)
-
-	// verify shifted time is not in UTC location
-	s.NotEqual(utc.Location(), nonUtc.Location())
+	utc, nonUtc := getTestTimes(s.Assertions)
 
 	formatter := rslog.NewUTCJSONFormatter()
 
@@ -406,32 +383,7 @@ func (s *LoggerImplTestSuite) TestUTCJSONFormatter() {
 
 func (s *LoggerImplTestSuite) TestUTCTextFormatter() {
 
-	// create a test location 1 hr east of UTC
-	loc := time.FixedZone("test/zone", 3600)
-	utc := time.Now().UTC()
-
-	// shift UTC time to the test location
-	nonUtc := utc.In(loc)
-
-	// verify shifted time is 1 hr ahead
-	expected := utc.Add(time.Hour)
-
-	expYear, expMonth, expDay := expected.Date()
-	nonUtcYear, nonUtcMonth, nonUtcDay := nonUtc.Date()
-
-	s.Equal(expYear, nonUtcYear)
-	s.Equal(expMonth, nonUtcMonth)
-	s.Equal(expDay, nonUtcDay)
-
-	expHour, expMin, expSec := expected.Clock()
-	nonUtcHour, nonUtcMin, nonUtcSec := nonUtc.Clock()
-
-	s.Equal(expHour, nonUtcHour)
-	s.Equal(expMin, nonUtcMin)
-	s.Equal(expSec, nonUtcSec)
-
-	// verify shifted time is not in UTC location
-	s.NotEqual(utc.Location(), nonUtc.Location())
+	utc, nonUtc := getTestTimes(s.Assertions)
 
 	formatter := rslog.NewUTCTextFormatter()
 
@@ -451,4 +403,37 @@ func (s *LoggerImplTestSuite) TestUTCTextFormatter() {
 	// assert that UTC time appears in the formatted entry
 	utcTimestamp := utc.Format(formatter.TimestampFormat)
 	s.True(strings.Contains(result, utcTimestamp))
+}
+
+// returns a tuple containing a UTC time and its conversion to a test timezone 1 hr east of UTC.
+// assertions are included to prove that we have created the intended times.
+func getTestTimes(a *assert.Assertions) (time.Time, time.Time) {
+	// create a test location 1 hr east of UTC
+	loc := time.FixedZone("test/zone", 3600)
+	utc := time.Now().UTC()
+
+	// shift UTC time to the test location
+	nonUtc := utc.In(loc)
+
+	// verify shifted time is 1 hr ahead
+	expected := utc.Add(time.Hour)
+
+	expYear, expMonth, expDay := expected.Date()
+	nonUtcYear, nonUtcMonth, nonUtcDay := nonUtc.Date()
+
+	a.Equal(expYear, nonUtcYear)
+	a.Equal(expMonth, nonUtcMonth)
+	a.Equal(expDay, nonUtcDay)
+
+	expHour, expMin, expSec := expected.Clock()
+	nonUtcHour, nonUtcMin, nonUtcSec := nonUtc.Clock()
+
+	a.Equal(expHour, nonUtcHour)
+	a.Equal(expMin, nonUtcMin)
+	a.Equal(expSec, nonUtcSec)
+
+	// verify shifted time is not in UTC location
+	a.NotEqual(utc.Location(), nonUtc.Location())
+
+	return utc, nonUtc
 }

--- a/pkg/rslog/rslogtest/terminal_logger_factory_test.go
+++ b/pkg/rslog/rslogtest/terminal_logger_factory_test.go
@@ -33,5 +33,5 @@ func (s *TerminalLoggerFactorySuite) TestTerminalLoggerFactory() {
 
 	s.Equal(logrus.InfoLevel, lgr_impl.Level)
 	s.Equal(os.Stderr, lgr_impl.Out)
-	s.IsType(&logrus.TextFormatter{}, lgr_impl.Formatter)
+	s.IsType(&rslog.UTCTextFormatter{}, lgr_impl.Formatter)
 }


### PR DESCRIPTION
Creates custom JSON / Text entry formatters which enforce UTC time conversion.

These are basically just wrappers around the logrus formatters which perform an extra time conversion on the entry field. 

Solution reference: 

https://stackoverflow.com/questions/40502309/how-can-i-set-the-logrus-time-to-utc

Fixes: 

https://github.com/rstudio/connect/issues/21579

