### PR TITLE
Enable debug logging regions messages for when legacy debug is removed

### DIFF
--- a/examples/cmd/testlog/cmd/root.go
+++ b/examples/cmd/testlog/cmd/root.go
@@ -41,6 +41,10 @@ var (
 )
 
 func init() {
+	// Install the default logger factory. If this is not set, then `rslog` will create
+	// its own default logger factory.
+	rslog.DefaultLoggerFactory = &factory{}
+
 	// Register product debug regions and initialize debug logging
 	rslog.RegisterRegions(map[rslog.ProductRegion]string{
 		TestDebug: "test-debug",
@@ -48,10 +52,6 @@ func init() {
 	rslog.InitDebugLogs([]rslog.ProductRegion{
 		TestDebug,
 	})
-
-	// Install the default logger factory. If this is not set, then `rslog` will create
-	// its own default logger factory.
-	rslog.DefaultLoggerFactory = &factory{}
 
 	// The `--level` flag is available for all commands.
 	RootCmd.PersistentFlags().StringVar(&level, "level", "DEBUG", "The log level.")

--- a/pkg/rslog/NEWS.md
+++ b/pkg/rslog/NEWS.md
@@ -1,0 +1,103 @@
+# `rslog` package 
+
+Unreleased
+--------------------------------------------------------------------------------
+
+### New
+
+*   Log enabled debug logging regions. This was previously done in product by the legacy debug
+    implementation. Important to note that intializing debug logging will set and use a default factory
+		to `DefaultLoggerFactory`, consider setting `rslog.DefaultLoggerFactory` first before anything else
+		when a custom factory is needed. #94
+
+<!--
+### Fixed
+
+*   Uncomment when items are available.
+-->
+
+<!--
+### Breaking
+
+*   Uncomment when items are available.
+-->
+
+<!--
+### Deprecated / Removed
+
+*   Uncomment when items are available.
+-->
+
+<!--
+### New Contributors
+
+*   Uncomment when items are available.
+-->
+
+
+pkg/rslog/v1.5.0
+--------------------------------------------------------------------------------
+June 6, 2022
+
+### New
+*   Doc updates by @mcbex in #84
+*   Enforce UTC conversion in log timestamps #88
+
+### Fixed
+*   '-buildvcs=false' for temporary build fix #87
+
+
+pkg/rslog/v1.4.0
+--------------------------------------------------------------------------------
+April 11, 2022
+
+### New
+*   Do not create log directories. `rslog` is not responsible for default log directories that should already exist or be created via product.
+
+
+pkg/rslog/v1.3.0
+--------------------------------------------------------------------------------
+March 1, 2022
+
+### New
+*   Add enhanced terminal logging to rslog #62
+
+
+pkg/rslog/v1.2.0
+--------------------------------------------------------------------------------
+February 22, 2022
+
+### Fixed
+*   Fix concurrent writes to debug callbacks registry
+
+
+pkg/rslog/v1.1.0
+--------------------------------------------------------------------------------
+February 2, 2022
+
+### New
+*   Removed rslog/debug package by moving debug logic into rslog(API-breaking change) #53
+
+### Fixed
+*   Fixed bugs in mocked logger's Fatal implementation #56
+*   Fixed debug child loggers not being enabled #55
+
+
+pkg/rslog/v1.0.0
+--------------------------------------------------------------------------------
+January 18, 2022
+
+### New
+*   Make each rsnotify listener implementation a module #36
+*   Split into multiple Go modules #35
+*   Use correct Go version in CI #38
+
+
+## Full Changelog:
+- [Unreleased](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.5.0...HEAD)
+- [1.5.0](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.4.0...pkg/rslog/v1.5.0)
+- [1.4.0](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.3.0...pkg/rslog/v1.4.0)
+- [1.3.0](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.2.0...pkg/rslog/v1.3.0)
+- [1.2.0](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.1.0...pkg/rslog/v1.2.0)
+- [1.1.0](https://github.com/rstudio/platform-lib/compare/pkg/rslog/v1.0.0...pkg/rslog/v1.1.0)
+- [1.0.0](https://github.com/rstudio/platform-lib/compare/v0.1.8...pkg/rslog/v1.0.0)

--- a/pkg/rslog/debug.go
+++ b/pkg/rslog/debug.go
@@ -60,6 +60,7 @@ func InitDebugLogs(regions []ProductRegion) {
 
 	// Reset enabled regions on each call.
 	regionsEnabled = make(map[ProductRegion]bool)
+	lgr := DefaultLogger()
 
 	// match debug log region to list
 	for _, region := range regions {
@@ -67,14 +68,8 @@ func InitDebugLogs(regions []ProductRegion) {
 			continue
 		}
 		regionsEnabled[region] = true
-		// TODO: On logging feature completion,
-		// Use the below commented out lines when
-		// debug.InitLog at config.go isn't used anymore
-
-		// regionName := DebugRegionName(region)
-		// if we normalized, print both the enabled region and
-		// the original input.
-		// Infof("Debug logging enabled for area: %s", regionName)
+		regionName := RegionName(region)
+		lgr.Infof("Debug logging enabled for area: %s", regionName)
 	}
 }
 

--- a/pkg/rslog/rslogtest/debug_test.go
+++ b/pkg/rslog/rslogtest/debug_test.go
@@ -28,12 +28,27 @@ func TestDebugLoggerSuite(t *testing.T) {
 	suite.Run(t, &DebugLoggerSuite{})
 }
 
+func (s *DebugLoggerSuite) SetupTest() {
+	rslog.RegisterRegions(map[rslog.ProductRegion]string{
+		LDAP:    "ldap",
+		Session: "session",
+		OAuth2:  "oauth2",
+		Proxy:   "proxy",
+		RProc:   "rproc",
+		Router:  "router",
+	})
+}
+
 func (s *DebugLoggerSuite) TestInitLog() {
+	loggerMock.On("Infof", "Debug logging enabled for area: %s", mock.Anything).Return(loggerMock)
+
 	s.False(rslog.Enabled(Proxy))
 
 	// Singular region enabled.
 	rslog.InitDebugLogs([]rslog.ProductRegion{Proxy})
 	s.True(rslog.Enabled(Proxy))
+	s.Equal(loggerMock.LastCall(), "Debug logging enabled for area: proxy")
+	loggerMock.Clear()
 
 	// multiple regions enabled (using translation and normalization)
 	rslog.InitDebugLogs([]rslog.ProductRegion{
@@ -44,20 +59,24 @@ func (s *DebugLoggerSuite) TestInitLog() {
 	s.True(rslog.Enabled(Proxy))
 	s.True(rslog.Enabled(RProc))
 	s.True(rslog.Enabled(Router))
+	s.Equal(loggerMock.Call(0), "Debug logging enabled for area: proxy")
+	s.Equal(loggerMock.Call(1), "Debug logging enabled for area: rproc")
+	s.Equal(loggerMock.Call(2), "Debug logging enabled for area: router")
+	loggerMock.Clear()
 
 	// calling InitDebugLogs resets what is enabled.
 	rslog.InitDebugLogs(nil)
 	s.False(rslog.Enabled(Proxy))
 	s.False(rslog.Enabled(RProc))
 	s.False(rslog.Enabled(Router))
+	s.Len(loggerMock.Calls, 0)
+	loggerMock.Clear()
 }
 
 func (s *DebugLoggerSuite) TestNewDebugLogger() {
 	loggerMock.On("Debugf", "test call %s", mock.Anything).Return(loggerMock)
-	loggerMock.On("WithFields", rslog.Fields{"region": ""}).Return(loggerMock)
-	loggerMock.On("WithFields", rslog.Fields{"id": "654-987"}).Return(loggerMock)
-	loggerMock.On("WithField", "sub_region", "balancer").Return(loggerMock)
 
+	loggerMock.On("WithFields", rslog.Fields{"region": "proxy"}).Return(loggerMock)
 	lgr := rslog.NewDebugLogger(Proxy)
 	defer rslog.Disable(Proxy)
 	s.Equal(lgr.Enabled(), false)
@@ -68,12 +87,14 @@ func (s *DebugLoggerSuite) TestNewDebugLogger() {
 	s.Equal(loggerMock.LastCall(), "test call base parent")
 
 	// Logger with fields should be under same region, new callback
+	loggerMock.On("WithFields", rslog.Fields{"id": "654-987"}).Return(loggerMock)
 	fieldslgr := lgr.WithFields(rslog.Fields{"id": "654-987"})
 	fieldslgr.Debugf("test call %s", "with-fields")
 	s.Equal(fieldslgr.Enabled(), true)
 	s.Equal(loggerMock.LastCall(), "test call with-fields")
 
 	// SubRegion Logger should be under same region, new callback
+	loggerMock.On("WithField", "sub_region", "balancer").Return(loggerMock)
 	sublgr := lgr.WithSubRegion("balancer")
 	sublgr.Debugf("test call %s", "subregion")
 	s.Equal(sublgr.Enabled(), true)
@@ -91,11 +112,13 @@ func (s *DebugLoggerSuite) TestNewDebugLogger() {
 	s.Equal(loggerMock.LastCall(), "test call LAST")
 
 	// For a totally different region
+	loggerMock.On("WithFields", rslog.Fields{"region": "ldap"}).Return(loggerMock)
 	another := rslog.NewDebugLogger(LDAP)
 	s.Equal(another.Enabled(), false)
 }
 
 func (s *DebugLoggerSuite) TestUpdateToLevelAndCaller() {
+	loggerMock.On("WithFields", rslog.Fields{"region": "oauth2"}).Return(loggerMock)
 	base := &LoggerMock{}
 	lgr := rslog.NewDebugLogger(OAuth2)
 	lgr.Logger = base
@@ -105,6 +128,7 @@ func (s *DebugLoggerSuite) TestUpdateToLevelAndCaller() {
 	base.AssertExpectations(s.T())
 
 	// Sub loggers
+	loggerMock.On("WithFields", rslog.Fields{"region": "session"}).Return(loggerMock)
 	baseTwo := &LoggerMock{}
 	lgr = rslog.NewDebugLogger(Session)
 	lgr.Logger = baseTwo

--- a/test/e2e/test_general.py
+++ b/test/e2e/test_general.py
@@ -37,4 +37,4 @@ def test_command(lib_env):
         # Run with an unknown command
         args = [f"{lib_env.asset_dir}/testlog", "log", "--message", "expected output"]
         output = res.run_command(args)
-        assert re.match('{"level":"info","msg":"expected output","time":".+"}', output)
+        assert re.search('{"level":"info","msg":"expected output","time":".+"}', output)


### PR DESCRIPTION
With the removal of the legacy debug package in Connect, we can now have a version of rslog that is responsible for showing messages of the regions enabled.