### PR TITLE
Buffer logs for default logger

### DIFF
--- a/examples/cmd/testlog/cmd/log.go
+++ b/examples/cmd/testlog/cmd/log.go
@@ -18,6 +18,7 @@ func init() {
 	LogCmd.Example = `  testlog log --message=hello --level=INFO
 `
 	LogCmd.Flags().StringVar(&message, "message", "default message", "The message to log.")
+	BufferedLogCmd.Flags().StringVar(&message, "message", "default message", "The message to log.")
 	CaptureLogCmd.Flags().BoolVar(&withMetadata, "withMetadata", false, "The option to turn on or off the metadata in the capturing logger")
 
 	RootCmd.AddCommand(LogCmd, TerminalLogCmd, CaptureLogCmd, CompositeLogCmd, BufferedLogCmd)
@@ -86,12 +87,13 @@ var BufferedLogCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		defaultLogger := rslog.DefaultLogger()
 
-		rslog.Buffer()
-
 		log := defaultLogger.WithField("Logger", "DefaultLogger")
-		log.Infof(message)
+		log.Warnf(message)
 
-		rslog.Flush()
+		// Since logs are only flushed after the command's execution, setting a new log level
+		// before that will make flushed logs respect the newly set level, even if the log call
+		// happened before setting the new level (works with output too).
+		log.SetLevel(rslog.WarningLevel)
 
 		return nil
 	},

--- a/examples/cmd/testlog/cmd/log.go
+++ b/examples/cmd/testlog/cmd/log.go
@@ -20,7 +20,7 @@ func init() {
 	LogCmd.Flags().StringVar(&message, "message", "default message", "The message to log.")
 	CaptureLogCmd.Flags().BoolVar(&withMetadata, "withMetadata", false, "The option to turn on or off the metadata in the capturing logger")
 
-	RootCmd.AddCommand(LogCmd, TerminalLogCmd, CaptureLogCmd, CompositeLogCmd)
+	RootCmd.AddCommand(LogCmd, TerminalLogCmd, CaptureLogCmd, CompositeLogCmd, BufferedLogCmd)
 }
 
 var LogCmd = &cobra.Command{
@@ -75,6 +75,24 @@ var CompositeLogCmd = &cobra.Command{
 		log := rslog.ComposeLoggers(defaultLogger, anotherLogger)
 
 		log.Infof(message)
+		return nil
+	},
+}
+
+var BufferedLogCmd = &cobra.Command{
+	Use:     "buffered",
+	Short:   "Command to use the Default logger with buffering functionality",
+	Example: "",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		defaultLogger := rslog.DefaultLogger()
+
+		rslog.Buffer()
+
+		log := defaultLogger.WithField("Logger", "DefaultLogger")
+		log.Infof(message)
+
+		rslog.Flush()
+
 		return nil
 	},
 }

--- a/examples/cmd/testlog/cmd/root.go
+++ b/examples/cmd/testlog/cmd/root.go
@@ -44,6 +44,8 @@ func init() {
 	// Install the default logger factory. If this is not set, then `rslog` will create
 	// its own default logger factory.
 	rslog.DefaultLoggerFactory = &factory{}
+	// Logs will be buffered until explicitly flushed.
+	rslog.Buffer()
 
 	// Register product debug regions and initialize debug logging
 	rslog.RegisterRegions(map[rslog.ProductRegion]string{

--- a/examples/cmd/testlog/main.go
+++ b/examples/cmd/testlog/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/rstudio/platform-lib/examples/cmd/testlog/cmd"
+	"github.com/rstudio/platform-lib/pkg/rslog"
 )
 
 func init() {
@@ -17,6 +18,11 @@ func main() {
 	log.SetOutput(os.Stdout)
 	cmd.RootCmd.SetOut(os.Stdout)
 	cmd.RootCmd.SetErr(os.Stderr)
+
+	// Since logs have been buffered (during root init), this will flush
+	// all buffered logs after the program exits.
+	defer rslog.Flush()
+
 	// Each command is in the cmd subdirectory and the RootCmd houses
 	// the global and inherited properties.
 	err := cmd.RootCmd.Execute()

--- a/pkg/rslog/NEWS.md
+++ b/pkg/rslog/NEWS.md
@@ -10,6 +10,9 @@ Unreleased
 		to `DefaultLoggerFactory`, consider setting `rslog.DefaultLoggerFactory` first before anything else
 		when a custom factory is needed. #94
 
+*   New functions `rslog.Buffer` and `rslog.Flush` have been added. They enable buffering functionality for
+    default loggers whose factories use `rslog.LoggerImpl` as their implementation.
+
 <!--
 ### Fixed
 

--- a/pkg/rslog/buf_logger.go
+++ b/pkg/rslog/buf_logger.go
@@ -51,7 +51,7 @@ func NewBufLogger(coreLogger CoreLoggerImpl, flush func()) *BufLogger {
 }
 
 func (buf *BufLogger) Tracef(msg string, args ...interface{}) {
-	buf.storage.entries = append(buf.storage.entries, BufLogEntry{
+	buf.storage.add(BufLogEntry{
 		Level:   TraceLevel,
 		Message: msg,
 		Args:    args,
@@ -60,7 +60,7 @@ func (buf *BufLogger) Tracef(msg string, args ...interface{}) {
 }
 
 func (buf *BufLogger) Debugf(msg string, args ...interface{}) {
-	buf.storage.entries = append(buf.storage.entries, BufLogEntry{
+	buf.storage.add(BufLogEntry{
 		Level:   DebugLevel,
 		Message: msg,
 		Args:    args,
@@ -69,7 +69,7 @@ func (buf *BufLogger) Debugf(msg string, args ...interface{}) {
 }
 
 func (buf *BufLogger) Infof(msg string, args ...interface{}) {
-	buf.storage.entries = append(buf.storage.entries, BufLogEntry{
+	buf.storage.add(BufLogEntry{
 		Level:   InfoLevel,
 		Message: msg,
 		Args:    args,
@@ -78,7 +78,7 @@ func (buf *BufLogger) Infof(msg string, args ...interface{}) {
 }
 
 func (buf *BufLogger) Warnf(msg string, args ...interface{}) {
-	buf.storage.entries = append(buf.storage.entries, BufLogEntry{
+	buf.storage.add(BufLogEntry{
 		Level:   WarningLevel,
 		Message: msg,
 		Args:    args,
@@ -86,7 +86,7 @@ func (buf *BufLogger) Warnf(msg string, args ...interface{}) {
 	})
 }
 func (buf *BufLogger) Errorf(msg string, args ...interface{}) {
-	buf.storage.entries = append(buf.storage.entries, BufLogEntry{
+	buf.storage.add(BufLogEntry{
 		Level:   ErrorLevel,
 		Message: msg,
 		Args:    args,

--- a/pkg/rslog/buf_logger.go
+++ b/pkg/rslog/buf_logger.go
@@ -16,16 +16,18 @@ type BufStorage struct {
 type BufLogger struct {
 	CoreLogger CoreLoggerImpl
 	Storage    *BufStorage
+	flush      func()
 }
 
 var _ CoreLoggerImpl = new(BufLogger)
 
-func NewBufLogger(coreLogger CoreLoggerImpl) *BufLogger {
+func NewBufLogger(coreLogger CoreLoggerImpl, flush func()) *BufLogger {
 	return &BufLogger{
 		Storage: &BufStorage{
 			Logs: make([]BufLogEntry, 0),
 		},
 		CoreLogger: coreLogger,
+		flush:      flush,
 	}
 }
 
@@ -83,22 +85,16 @@ func (buf *BufLogger) Errorf(msg string, args ...interface{}) {
 }
 
 func (buf *BufLogger) Fatal(args ...interface{}) {
-	if f, ok := buf.CoreLogger.(Flusher); ok {
-		f.Flush()
-	}
+	buf.flush()
 	buf.CoreLogger.Fatal(args...)
 }
 
 func (buf *BufLogger) Fatalf(msg string, args ...interface{}) {
-	if f, ok := buf.CoreLogger.(Flusher); ok {
-		f.Flush()
-	}
+	buf.flush()
 	buf.CoreLogger.Fatalf(msg, args...)
 }
 
 func (buf *BufLogger) Panicf(msg string, args ...interface{}) {
-	if f, ok := buf.CoreLogger.(Flusher); ok {
-		f.Flush()
-	}
+	buf.flush()
 	buf.CoreLogger.Panicf(msg, args...)
 }

--- a/pkg/rslog/buf_logger.go
+++ b/pkg/rslog/buf_logger.go
@@ -6,7 +6,7 @@ type BufLogEntry struct {
 	Level   LogLevel
 	Message string
 	Args    []interface{}
-	Logger  loggerImpl
+	Logger  CoreLoggerImpl
 }
 
 type BufStorage struct {
@@ -14,13 +14,13 @@ type BufStorage struct {
 }
 
 type BufLogger struct {
-	CoreLogger loggerImpl
+	CoreLogger CoreLoggerImpl
 	Storage    *BufStorage
 }
 
-var _ loggerImpl = new(BufLogger)
+var _ CoreLoggerImpl = new(BufLogger)
 
-func NewBufLogger(coreLogger loggerImpl) *BufLogger {
+func NewBufLogger(coreLogger CoreLoggerImpl) *BufLogger {
 	return &BufLogger{
 		Storage: &BufStorage{
 			Logs: make([]BufLogEntry, 0),
@@ -31,7 +31,7 @@ func NewBufLogger(coreLogger loggerImpl) *BufLogger {
 
 // child creates and registers a wrapped logger implementation and returns a new buffered logger
 // that will pass down the same storage and fallback fields for its children, if any.
-func (buf *BufLogger) child(coreLogger loggerImpl) *BufLogger {
+func (buf *BufLogger) child(coreLogger CoreLoggerImpl) *BufLogger {
 	return &BufLogger{
 		CoreLogger: coreLogger,
 		Storage:    buf.Storage,
@@ -83,21 +83,21 @@ func (buf *BufLogger) Errorf(msg string, args ...interface{}) {
 }
 
 func (buf *BufLogger) Fatal(args ...interface{}) {
-	if f, ok := buf.CoreLogger.(flusher); ok {
+	if f, ok := buf.CoreLogger.(Flusher); ok {
 		f.Flush()
 	}
 	buf.CoreLogger.Fatal(args...)
 }
 
 func (buf *BufLogger) Fatalf(msg string, args ...interface{}) {
-	if f, ok := buf.CoreLogger.(flusher); ok {
+	if f, ok := buf.CoreLogger.(Flusher); ok {
 		f.Flush()
 	}
 	buf.CoreLogger.Fatalf(msg, args...)
 }
 
 func (buf *BufLogger) Panicf(msg string, args ...interface{}) {
-	if f, ok := buf.CoreLogger.(flusher); ok {
+	if f, ok := buf.CoreLogger.(Flusher); ok {
 		f.Flush()
 	}
 	buf.CoreLogger.Panicf(msg, args...)

--- a/pkg/rslog/buf_logger.go
+++ b/pkg/rslog/buf_logger.go
@@ -1,0 +1,107 @@
+package rslog
+
+// Copyright (C) 2022 by RStudio, PBC.
+
+import "github.com/sirupsen/logrus"
+
+type logEntry struct {
+	lvl     LogLevel
+	msg     string
+	args    []interface{}
+	wrapper *logrusEntryWrapper
+}
+
+type bufStorage struct {
+	logs     []logEntry
+	wrappers map[*logrusEntryWrapper]struct{}
+}
+
+type bufLogger struct {
+	wrapper    *logrusEntryWrapper
+	coreLogger loggerImpl
+	storage    *bufStorage
+	flusher    flusher
+}
+
+var _ loggerImpl = new(bufLogger)
+
+func newBufLogger(coreLogger *logrus.Logger) *bufLogger {
+	return &bufLogger{
+		storage: &bufStorage{
+			logs:     make([]logEntry, 0),
+			wrappers: make(map[*logrusEntryWrapper]struct{}),
+		},
+		coreLogger: coreLogger,
+	}
+}
+
+// child creates and registers a wrapped logger implementation and returns a new buffered logger
+// that will pass down the same storage and fallback fields for its children, if any.
+func (buf *bufLogger) child(wrapper *logrusEntryWrapper) *bufLogger {
+	buf.storage.wrappers[wrapper] = struct{}{}
+	return &bufLogger{
+		wrapper:    wrapper,
+		coreLogger: buf.coreLogger,
+		storage:    buf.storage,
+		flusher:    buf.flusher,
+	}
+}
+
+func (buf *bufLogger) Tracef(msg string, args ...interface{}) {
+	buf.storage.logs = append(buf.storage.logs, logEntry{
+		lvl:     TraceLevel,
+		msg:     msg,
+		args:    args,
+		wrapper: buf.wrapper,
+	})
+}
+
+func (buf *bufLogger) Debugf(msg string, args ...interface{}) {
+	buf.storage.logs = append(buf.storage.logs, logEntry{
+		lvl:     DebugLevel,
+		msg:     msg,
+		args:    args,
+		wrapper: buf.wrapper,
+	})
+}
+
+func (buf *bufLogger) Infof(msg string, args ...interface{}) {
+	buf.storage.logs = append(buf.storage.logs, logEntry{
+		lvl:     InfoLevel,
+		msg:     msg,
+		args:    args,
+		wrapper: buf.wrapper,
+	})
+}
+
+func (buf *bufLogger) Warnf(msg string, args ...interface{}) {
+	buf.storage.logs = append(buf.storage.logs, logEntry{
+		lvl:     WarningLevel,
+		msg:     msg,
+		args:    args,
+		wrapper: buf.wrapper,
+	})
+}
+func (buf *bufLogger) Errorf(msg string, args ...interface{}) {
+	buf.storage.logs = append(buf.storage.logs, logEntry{
+		lvl:     ErrorLevel,
+		msg:     msg,
+		args:    args,
+		wrapper: buf.wrapper,
+	})
+}
+
+func (buf *bufLogger) Fatal(args ...interface{}) {
+	buf.flusher.Flush()
+	buf.coreLogger.Fatal(args...)
+}
+
+func (buf *bufLogger) Fatalf(msg string, args ...interface{}) {
+	buf.flusher.Flush()
+	buf.coreLogger.Fatalf(msg, args...)
+}
+
+func (buf *bufLogger) Panicf(msg string, args ...interface{}) {
+	buf.flusher.Flush()
+	buf.coreLogger.Panicf(msg, args...)
+}

--- a/pkg/rslog/capturing_logger.go
+++ b/pkg/rslog/capturing_logger.go
@@ -118,7 +118,7 @@ func NewCapturingLogger(options CapturingLoggerOptions) CapturingLogger {
 
 	h := new(captureMessageHook)
 	h.metadata = options.WithMetadata
-	l.AddHook(h)
+	l.coreLogger.AddHook(h)
 
 	return CapturingLogger{
 		Logger: l,

--- a/pkg/rslog/capturing_logger.go
+++ b/pkg/rslog/capturing_logger.go
@@ -118,7 +118,7 @@ func NewCapturingLogger(options CapturingLoggerOptions) CapturingLogger {
 
 	h := new(captureMessageHook)
 	h.metadata = options.WithMetadata
-	l.coreLogger.AddHook(h)
+	l.CoreLogger.AddHook(h)
 
 	return CapturingLogger{
 		Logger: l,

--- a/pkg/rslog/logger.go
+++ b/pkg/rslog/logger.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-type Logger interface {
+type loggerImpl interface {
 	Debugf(msg string, args ...interface{})
 	Infof(msg string, args ...interface{})
 	Warnf(msg string, args ...interface{})
@@ -18,6 +18,10 @@ type Logger interface {
 	Fatal(args ...interface{})
 	Panicf(msg string, args ...interface{})
 	Tracef(msg string, args ...interface{})
+}
+
+type Logger interface {
+	loggerImpl
 
 	WithField(key string, value interface{}) Logger
 	WithFields(fields Fields) Logger

--- a/pkg/rslog/logger.go
+++ b/pkg/rslog/logger.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-type loggerImpl interface {
+type CoreLoggerImpl interface {
 	Debugf(msg string, args ...interface{})
 	Infof(msg string, args ...interface{})
 	Warnf(msg string, args ...interface{})
@@ -21,7 +21,7 @@ type loggerImpl interface {
 }
 
 type Logger interface {
-	loggerImpl
+	CoreLoggerImpl
 
 	WithField(key string, value interface{}) Logger
 	WithFields(fields Fields) Logger

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -284,30 +284,28 @@ var defaultLogger Logger
 var once = &sync.Once{}
 var mutex sync.RWMutex
 
-type buffer interface {
+type lazyLogger interface {
 	Buffer()
-}
-
-type flusher interface {
 	Flush()
 }
 
-// Buffer signals the default logger to buffer calls.
-// Returns a function that flushes the buffer.
+// Buffer makes the default logger (if supported by it) use a buffering logger
+// as its underlying implementation. Buffered log entries can be flushed with Flush.
 func Buffer() {
 	lock := ensureDefaultLoggerReadLock()
 	defer lock.RUnlock()
 
-	if b, ok := defaultLogger.(buffer); ok {
+	if b, ok := defaultLogger.(lazyLogger); ok {
 		b.Buffer()
 	}
 }
 
+// Flush flushes all buffered log entries that were retained as from calling Buffer.
 func Flush() {
 	lock := ensureDefaultLoggerReadLock()
 	defer lock.RUnlock()
 
-	if f, ok := defaultLogger.(flusher); ok {
+	if f, ok := defaultLogger.(lazyLogger); ok {
 		f.Flush()
 	}
 }

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -153,8 +153,6 @@ func (l *LoggerImpl) Buffer() {
 
 func (l *LoggerImpl) Flush() {
 	if bufLogger, ok := l.CoreLoggerImpl.(*BufLogger); ok {
-		storage := bufLogger.Storage
-
 		// Swap logger implementations and allow wrappers set to be garbage-collected.
 		l.CoreLoggerImpl = l.CoreLogger
 		for wrapper := range l.wrappers {
@@ -166,7 +164,7 @@ func (l *LoggerImpl) Flush() {
 		l.wrappers = nil
 
 		// Time to output retained logs to their respective loggers.
-		for _, entry := range storage.Logs {
+		bufLogger.Read(func(entry BufLogEntry) {
 			lgr := entry.Logger
 
 			switch entry.Level {
@@ -181,7 +179,7 @@ func (l *LoggerImpl) Flush() {
 			case ErrorLevel:
 				lgr.Errorf(entry.Message, entry.Args...)
 			}
-		}
+		})
 	}
 }
 

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -185,7 +185,7 @@ func (l *LoggerImpl) Flush() {
 
 func (l LoggerImpl) WithField(key string, value interface{}) Logger {
 	e := l.CoreLogger.WithField(key, value)
-	return wrapBufLoggerChild(l.CoreLogger, l.wrappers, e)
+	return wrapBufLoggerChild(l.CoreLoggerImpl, l.wrappers, e)
 }
 
 func (l LoggerImpl) WithFields(fields Fields) Logger {
@@ -243,13 +243,13 @@ func (l logrusEntryWrapper) SetFormatter(format OutputFormat) {
 
 func (l logrusEntryWrapper) WithField(key string, value interface{}) Logger {
 	e := l.coreLogger.WithField(key, value)
-	return wrapBufLoggerChild(l.coreLogger, l.wrappers, e)
+	return wrapBufLoggerChild(l.CoreLoggerImpl, l.wrappers, e)
 
 }
 
 func (l logrusEntryWrapper) WithFields(fields Fields) Logger {
 	e := l.coreLogger.WithFields(logrus.Fields(fields))
-	return wrapBufLoggerChild(l.coreLogger, l.wrappers, e)
+	return wrapBufLoggerChild(l.CoreLoggerImpl, l.wrappers, e)
 }
 
 // TODO: remove this function when the migration process to the new logging standard is complete.

--- a/pkg/rslog/logger_impl.go
+++ b/pkg/rslog/logger_impl.go
@@ -39,7 +39,7 @@ func (f *LoggerFactoryImpl) DefaultLogger() Logger {
 			logs:     make([]logEntry, 0),
 			wrappers: make(map[*logrusEntryWrapper]struct{}),
 		},
-		coreLogger: lgr.coreLogger,
+		coreLogger: lgr.CoreLogger,
 		flusher:    lgr,
 	}
 	lgr.loggerImpl = lgr.bufLogger
@@ -61,7 +61,7 @@ func (f *TerminalLoggerFactory) DefaultLogger() Logger {
 
 type LoggerImpl struct {
 	loggerImpl
-	coreLogger *logrus.Logger
+	CoreLogger *logrus.Logger
 	bufLogger  *bufLogger
 }
 
@@ -87,7 +87,7 @@ func NewLoggerImpl(options LoggerOptionsImpl,
 	l.SetLevel(getLevel(options.Level))
 
 	return &LoggerImpl{
-		coreLogger: l,
+		CoreLogger: l,
 		loggerImpl: l,
 	}, nil
 }
@@ -158,7 +158,7 @@ func getLevel(level LogLevel) logrus.Level {
 func (l *LoggerImpl) Flush() {
 	flushOnce.Do(func() {
 		storage := l.bufLogger.storage
-		l.loggerImpl = l.coreLogger
+		l.loggerImpl = l.CoreLogger
 		l.bufLogger = nil
 
 		for wrapper := range storage.wrappers {
@@ -189,7 +189,7 @@ func (l *LoggerImpl) Flush() {
 }
 
 func (l LoggerImpl) WithField(key string, value interface{}) Logger {
-	e := l.coreLogger.WithField(key, value)
+	e := l.CoreLogger.WithField(key, value)
 	wrapper := &logrusEntryWrapper{coreLogger: e}
 	if l.bufLogger != nil {
 		wrapper.bufLogger = l.bufLogger.child(wrapper)
@@ -202,7 +202,7 @@ func (l LoggerImpl) WithField(key string, value interface{}) Logger {
 }
 
 func (l LoggerImpl) WithFields(fields Fields) Logger {
-	e := l.coreLogger.WithFields(logrus.Fields(fields))
+	e := l.CoreLogger.WithFields(logrus.Fields(fields))
 	wrapper := &logrusEntryWrapper{coreLogger: e}
 	if l.bufLogger != nil {
 		wrapper.bufLogger = l.bufLogger.child(wrapper)
@@ -216,22 +216,22 @@ func (l LoggerImpl) WithFields(fields Fields) Logger {
 
 func (l LoggerImpl) SetLevel(level LogLevel) {
 	logrusLevel := getLevel(level)
-	l.coreLogger.SetLevel(logrusLevel)
+	l.CoreLogger.SetLevel(logrusLevel)
 }
 
 func (l LoggerImpl) SetFormatter(format OutputFormat) {
-	l.coreLogger.SetFormatter(getFormatter(format))
+	l.CoreLogger.SetFormatter(getFormatter(format))
 }
 
 func (l LoggerImpl) SetOutput(writers ...io.Writer) {
 	output := io.MultiWriter(writers...)
-	l.coreLogger.SetOutput(output)
+	l.CoreLogger.SetOutput(output)
 }
 
 func (l LoggerImpl) OnConfigReload(level LogLevel) {
 	logrusLevel := getLevel(level)
 
-	if logrusLevel != l.coreLogger.GetLevel() {
+	if logrusLevel != l.CoreLogger.GetLevel() {
 		l.SetLevel(level)
 		l.Infof("Logging level changed to %s", level)
 	}

--- a/pkg/rslog/rslogtest/buf_logger_test.go
+++ b/pkg/rslog/rslogtest/buf_logger_test.go
@@ -36,8 +36,13 @@ func (s *BufLoggerTestSuite) TestBuffering() {
 		})
 	}
 
+	result := make([]rslog.BufLogEntry, 0)
+	bufLogger.Read(func(entry rslog.BufLogEntry) {
+		result = append(result, entry)
+	})
+
 	s.Assert().Equal(
-		bufLogger.Storage.Logs,
+		result,
 		[]rslog.BufLogEntry{
 			{
 				Level:   rslog.DebugLevel,

--- a/pkg/rslog/rslogtest/buf_logger_test.go
+++ b/pkg/rslog/rslogtest/buf_logger_test.go
@@ -1,0 +1,74 @@
+package rslogtest
+
+import (
+	"testing"
+
+	"github.com/rstudio/platform-lib/pkg/rslog"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+// Copyright (C) 2022 by RStudio, PBC.
+
+type BufLoggerTestSuite struct {
+	suite.Suite
+}
+
+func TestBufLoggerSuite(t *testing.T) {
+	suite.Run(t, &BufLoggerTestSuite{})
+}
+
+func (s *BufLoggerTestSuite) TestBuffering() {
+	coreLogger := &LoggerMock{}
+	methods := []string{"Errorf", "Warnf", "Debugf", "Infof", "Tracef"}
+	coreLogger.AllowAny(methods...)
+
+	bufLogger := rslog.NewBufLogger(coreLogger)
+	bufLogger.Debugf("testing %s", "debug")
+	bufLogger.Errorf("testing %s", "error")
+	bufLogger.Infof("testing %s", "info")
+	bufLogger.Warnf("testing %s", "warn")
+	bufLogger.Tracef("testing %s", "trace")
+
+	for _, m := range methods {
+		s.T().Run(m, func(t *testing.T) {
+			coreLogger.AssertNotCalled(t, m, mock.Anything)
+		})
+	}
+
+	s.Assert().Equal(
+		bufLogger.Storage.Logs,
+		[]rslog.BufLogEntry{
+			{
+				Level:   rslog.DebugLevel,
+				Message: "testing %s",
+				Args:    []interface{}{"debug"},
+				Logger:  coreLogger,
+			},
+			{
+				Level:   rslog.ErrorLevel,
+				Message: "testing %s",
+				Args:    []interface{}{"error"},
+				Logger:  coreLogger,
+			},
+			{
+				Level:   rslog.InfoLevel,
+				Message: "testing %s",
+				Args:    []interface{}{"info"},
+				Logger:  coreLogger,
+			},
+			{
+				Level:   rslog.WarningLevel,
+				Message: "testing %s",
+				Args:    []interface{}{"warn"},
+				Logger:  coreLogger,
+			},
+			{
+				Level:   rslog.TraceLevel,
+				Message: "testing %s",
+				Args:    []interface{}{"trace"},
+				Logger:  coreLogger,
+			},
+		},
+	)
+}

--- a/pkg/rslog/rslogtest/logger_impl_test.go
+++ b/pkg/rslog/rslogtest/logger_impl_test.go
@@ -52,8 +52,8 @@ func (s *LoggerImplTestSuite) TestNewLoggerImpl() {
 		outputMock,
 	)
 	s.Nil(err)
-	s.Equal(expectedOutput, result.Out)
-	s.IsType(&rslog.UTCTextFormatter{}, result.Formatter)
+	s.Equal(expectedOutput, result.CoreLogger.Out)
+	s.IsType(&rslog.UTCTextFormatter{}, result.CoreLogger.Formatter)
 
 	result, err = rslog.NewLoggerImpl(
 		rslog.LoggerOptionsImpl{
@@ -64,7 +64,7 @@ func (s *LoggerImplTestSuite) TestNewLoggerImpl() {
 		outputMock,
 	)
 	s.Nil(err)
-	s.IsType(&rslog.UTCJSONFormatter{}, result.Formatter)
+	s.IsType(&rslog.UTCJSONFormatter{}, result.CoreLogger.Formatter)
 
 	result, err = rslog.NewLoggerImpl(
 		rslog.LoggerOptionsImpl{
@@ -75,7 +75,7 @@ func (s *LoggerImplTestSuite) TestNewLoggerImpl() {
 		outputMock,
 	)
 	s.Nil(err)
-	s.IsType(&rslog.UTCTextFormatter{}, result.Formatter)
+	s.IsType(&rslog.UTCTextFormatter{}, result.CoreLogger.Formatter)
 
 	errdBuildMock := &OutputBuilderMock{}
 	errdBuildMock.On("Build", outputDest).Return(IoWriterMock{}, fmt.Errorf("output build error"))
@@ -249,10 +249,7 @@ func (s *LoggerImplTestSuite) TestNewLoggerImplLevel() {
 				outputMock,
 			)
 			s.Nil(err)
-
-			logrusLogger := lgr.Logger
-
-			s.Equal(tc.ExpectedLogrusLogLevel, logrusLogger.GetLevel())
+			s.Equal(tc.ExpectedLogrusLogLevel, lgr.CoreLogger.GetLevel())
 		})
 	}
 
@@ -339,13 +336,13 @@ func (s *LoggerImplTestSuite) TestOnConfigReload() {
 	)
 	s.Nil(err)
 
-	s.Equal(log.Level, logrus.InfoLevel)
+	s.Equal(log.CoreLogger.Level, logrus.InfoLevel)
 
 	log.OnConfigReload(rslog.WarningLevel)
 
-	s.NotNil(log.Out)
-	s.Equal(log.Level, logrus.WarnLevel)
-	s.IsType(&rslog.UTCJSONFormatter{}, log.Formatter)
+	s.NotNil(log.CoreLogger.Out)
+	s.Equal(log.CoreLogger.Level, logrus.WarnLevel)
+	s.IsType(&rslog.UTCJSONFormatter{}, log.CoreLogger.Formatter)
 }
 
 func (s *LoggerImplTestSuite) TestNewDiscardingLogger() {

--- a/pkg/rslog/rslogtest/terminal_logger_factory_test.go
+++ b/pkg/rslog/rslogtest/terminal_logger_factory_test.go
@@ -31,7 +31,7 @@ func (s *TerminalLoggerFactorySuite) TestTerminalLoggerFactory() {
 
 	lgr_impl := lgr.(*rslog.LoggerImpl)
 
-	s.Equal(logrus.InfoLevel, lgr_impl.Level)
-	s.Equal(os.Stderr, lgr_impl.Out)
-	s.IsType(&rslog.UTCTextFormatter{}, lgr_impl.Formatter)
+	s.Equal(logrus.InfoLevel, lgr_impl.CoreLogger.Level)
+	s.Equal(os.Stderr, lgr_impl.CoreLogger.Out)
+	s.IsType(&rslog.UTCTextFormatter{}, lgr_impl.CoreLogger.Formatter)
 }


### PR DESCRIPTION
## Description
This prevents log messages to be printed with undesired outputs/levels while the configuration file of a platform is not read yet.

A new logger implementation is introduced. This implementation buffers log calls --- from the main logger as well from its children loggers --- in order for them to be flushed later on.

The flush is done when the default logger is updated --- signaling that the necessary initial changes have been made, and it is now safe to print messages.

## How to test with Connect
- [x] Build Connect with [this branch](https://github.com/rstudio/connect/tree/gbrlsnchs-buf-logger) (that branch makes Connect use this branch for `rslog`, thus making use of these changes)
- [x] Assert that Connect starts up without panicking
- [x] Assert that no INFO logs get printed when `Logging.ServiceLogLevel` is `error` (make sure no debug log regions are on)
```ini
[Debug]
; Log = rproc
; Log = tfproc
; Log = pyproc
; Log = proc

[Logging]
ServiceLog = stdout
ServiceLogLevel = error
```
- [x] Assert that INFO logs get printed to a file and no entries escape to stdout:
```ini
[Logging]
ServiceLog = service.log
```
- [x] Make sure Connect prints all logs prior to a fatal error (one can force this by adding invalid fields to the config file)
```ini
[Logging]
Foo = bar
```