### PR TITLE
Add metrics interface

### DIFF
--- a/pkg/rsqueue/metrics/metrics.go
+++ b/pkg/rsqueue/metrics/metrics.go
@@ -1,0 +1,7 @@
+package metrics
+
+// Copyright (C) 2023 by RStudio, PBC
+
+type Metrics interface {
+	QueueNotificationMiss(queue, address string)
+}


### PR DESCRIPTION
Adds a metrics interface that can be used to record queue work complete notification misses.