### PR TITLE
Conditionally Enabled Work Types

### DIFF
--- a/pkg/rsqueue/runnerfactory/runnerfactory.go
+++ b/pkg/rsqueue/runnerfactory/runnerfactory.go
@@ -32,17 +32,24 @@ func (r *RunnerFactory) Add(workType uint64, runner queue.WorkRunner) {
 	r.types.SetEnabled(workType, true)
 }
 
+func (r *RunnerFactory) AddConditional(workType uint64, enabled func() bool, runner queue.WorkRunner) {
+	r.runners[workType] = runner
+	r.types.SetEnabledConditional(workType, enabled)
+}
+
+// Run runs work if the work type is configured. Note that this doesn't check to
+// see if the work type is enabled (in r.types).
 func (r *RunnerFactory) Run(work queue.RecursableWork) error {
 
 	runner, ok := r.runners[work.WorkType]
 	if !ok {
-		return fmt.Errorf("Invalid work type %d", work.WorkType)
+		return fmt.Errorf("invalid work type %d", work.WorkType)
 	}
 
 	return runner.Run(work)
 }
 
-// Stops all the runners in the factory. After each runner is stopped,
+// Stop all the runners in the factory. After each runner is stopped,
 // it is marked as disabled so that we won't attempt to grab future
 // work for that runner from the queue.
 func (r *RunnerFactory) Stop(timeout time.Duration) error {

--- a/pkg/rsqueue/runnerfactory/runnerfactory_test.go
+++ b/pkg/rsqueue/runnerfactory/runnerfactory_test.go
@@ -93,7 +93,31 @@ func (s *RunnerFactorySuite) TestNewRunner(c *check.C) {
 		Work:     []byte{},
 		WorkType: 2,
 	})
-	c.Assert(err, check.ErrorMatches, "Invalid work type 2")
+	c.Assert(err, check.ErrorMatches, "invalid work type 2")
+}
+
+func (s *RunnerFactorySuite) TestRunnerConditional(c *check.C) {
+	types := &queue.DefaultQueueSupportedTypes{}
+	r := NewRunnerFactory(RunnerFactoryConfig{SupportedTypes: types})
+	c.Check(r, check.DeepEquals, &RunnerFactory{
+		runners: make(map[uint64]queue.WorkRunner),
+		types:   types,
+	})
+
+	yes := func() bool {
+		return true
+	}
+	no := func() bool {
+		return false
+	}
+
+	// Add a runner
+	fr1 := &FakeRunnerOne{}
+	fr2 := &FakeRunnerTwo{}
+	r.AddConditional(0, yes, fr1)
+	r.AddConditional(1, no, fr2)
+	c.Check(r.runners, check.HasLen, 2)
+	c.Check(r.types.Enabled(), check.DeepEquals, []uint64{0})
 }
 
 func (s *RunnerFactorySuite) TestStop(c *check.C) {


### PR DESCRIPTION
There are cases where we may wish to run queued work for some types only when conditionally enabled. For example, you may wish for a leader node to run jobs that are not retrieved from the queue on follower nodes. This PR introduces the ability to conditionally enable a work type.