### PR TITLE
Check X-Amz header for unencrypted content length when using KMS

### DIFF
--- a/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
@@ -115,3 +115,7 @@ func (s *encryptedS3Service) GetObject(input *s3.GetObjectInput) (*s3.GetObjectO
 	}
 	return out, err
 }
+
+func (s *encryptedS3Service) KmsEncrypted() bool {
+	return true
+}

--- a/pkg/rsstorage/servers/s3server/s3_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_service.go
@@ -30,6 +30,7 @@ type S3Wrapper interface {
 	CopyObject(bucket, key, newBucket, newKey string) (*s3.CopyObjectOutput, error)
 	MoveObject(bucket, key, newBucket, newKey string) (*s3.CopyObjectOutput, error)
 	ListObjects(bucket, prefix string) ([]string, error)
+	KmsEncrypted() bool
 }
 
 type defaultS3Wrapper struct {
@@ -55,6 +56,10 @@ func NewS3Wrapper(configInput *rsstorage.ConfigS3, keyID string) (S3Wrapper, err
 	return &defaultS3Wrapper{
 		session: sess,
 	}, nil
+}
+
+func (s *defaultS3Wrapper) KmsEncrypted() bool {
+	return false
 }
 
 func (s *defaultS3Wrapper) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {

--- a/pkg/rsstorage/servers/s3server/server_test.go
+++ b/pkg/rsstorage/servers/s3server/server_test.go
@@ -78,6 +78,10 @@ type fakeS3 struct {
 	delBucketOut *s3.DeleteBucketOutput
 }
 
+func (s *fakeS3) KmsEncrypted() bool {
+	return false
+}
+
 func (s *fakeS3) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	if s.bucketErr == nil {
 		s.bucketIn = input


### PR DESCRIPTION
Checks the appropriate `X-Amz` header for the unencrypted content length of a file when checking or getting a file from S3 and using KMS.