### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -103,3 +103,111 @@ updates:
         dependency-type: "development"
     reviewers:
       - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rselection/impls/pgx"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rselection/impls/local"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsstorage/servers/s3server"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsstorage/servers/postgres"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsstorage/servers/file"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsnotify/listeners/postgrespgx"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsnotify/listeners/postgrespq"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsnotify/listeners/local"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+   - package-ecosystem: "gomod"
+    directory: "/pkg/rsqueue/impls/database"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,105 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rscache/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rselection/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rskey/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rslog/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rsnotify/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rsqueue/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"
+  - package-ecosystem: "gomod"
+    directory: "/pkg/rsstorage/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    reviewers:
+      - "rstudio/ppm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,213 +1,214 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rscache/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rscache/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rselection/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rselection/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rskey/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rskey/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rslog/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rslog/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rsnotify/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsnotify/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rsqueue/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsqueue/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rsstorage/"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsstorage/
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-  - package-ecosystem: "gomod"
-    directory: "/pkg/rselection/impls/pgx"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rselection/impls/pgx
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rselection/impls/local"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rselection/impls/local
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsstorage/servers/s3server"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsstorage/servers/s3server
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsstorage/servers/postgres"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsstorage/servers/postgres
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsstorage/servers/file"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsstorage/servers/file
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsnotify/listeners/postgrespgx"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsnotify/listeners/postgrespgx
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsnotify/listeners/postgrespq"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsnotify/listeners/postgrespq
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsnotify/listeners/local"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsnotify/listeners/local
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
-   - package-ecosystem: "gomod"
-    directory: "/pkg/rsqueue/impls/database"
+      - rstudio/ppm
+  - package-ecosystem: gomod
+    directory: /pkg/rsqueue/impls/database
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: weekly
+      day: sunday
     groups:
       production-dependencies:
-        dependency-type: "production"
+        dependency-type: production
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: development
     reviewers:
-      - "rstudio/ppm"
+      - rstudio/ppm


### PR DESCRIPTION
It would be good to keep the platform-lib dependencies up-to-date since Package Manager relies on it.