### PR TITLE
fix: use correct healthcheck

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.20.4'
+          go-version: '>=1.20.14'
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -50,7 +50,7 @@ services:
       MINIO_SECRET_KEY: miniokey
     command: minio server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
`curl` is not in the minio base image. Use the recommended healthcheck from minio.

See:
* https://github.com/minio/minio/issues/18389
* https://github.com/minio/minio/blob/a2f6252b2f508dc2f445b6c872754f9fa68acc49/docs/orchestration/docker-compose/docker-compose.yaml#L13-L17