### PR TITLE
rslogtest.LoggerMock: synchronize formatted messages

### DIFF
--- a/pkg/rslog/rslogtest/mocks_test.go
+++ b/pkg/rslog/rslogtest/mocks_test.go
@@ -3,8 +3,12 @@ package rslogtest
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"github.com/stretchr/testify/suite"
+	"fmt"
+	"regexp"
+	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 func TestPackage(t *testing.T) {
@@ -18,60 +22,92 @@ type MocksSuite struct {
 func (s *MocksSuite) TestLoggerMockCallStack() {
 
 	loggerMock := &LoggerMock{}
+	loggerMock.AllowAny("Debugf", "Tracef", "Info", "Infof", "Warnf", "Errorf", "Fatal", "Fatalf", "Panicf")
 
-	debugfStr := "Debugf"
-	tracefStr := "Tracef"
-	infoStr := "Info"
-	infofStr := "Infof"
-	warnfStr := "Warnf"
-	errorfStr := "Errorf"
-	fatalfStr := "Fatalf"
-	fatalStr := "Fatal"
-	panicfStr := "Panicf"
-
-	loggerMock.AllowAny(debugfStr, tracefStr, infoStr, infofStr, warnfStr, errorfStr, fatalfStr, fatalStr, panicfStr)
+	value := "the-value"
 
 	s.Equal(0, len(loggerMock.Calls))
 
-	loggerMock.Debugf(debugfStr)
-	s.Equal(debugfStr, loggerMock.LastCall())
-	s.Equal(debugfStr, loggerMock.Call(0))
+	loggerMock.Debugf("debugf '%s'", value)
+	s.Equal("debugf 'the-value'", loggerMock.LastCall())
+	s.Equal("debugf 'the-value'", loggerMock.Call(0))
 
-	loggerMock.Tracef(tracefStr)
-	s.Equal(tracefStr, loggerMock.LastCall())
-	s.Equal(tracefStr, loggerMock.Call(1))
+	loggerMock.Tracef("tracef '%s'", value)
+	s.Equal("tracef 'the-value'", loggerMock.LastCall())
+	s.Equal("tracef 'the-value'", loggerMock.Call(1))
 
-	loggerMock.Info(infoStr)
-	s.Equal(infoStr, loggerMock.LastCall())
-	s.Equal(infoStr, loggerMock.Call(2))
+	loggerMock.Info("info")
+	s.Equal("info", loggerMock.LastCall())
+	s.Equal("info", loggerMock.Call(2))
 
-	loggerMock.Infof(infofStr)
-	s.Equal(infofStr, loggerMock.LastCall())
-	s.Equal(infofStr, loggerMock.Call(3))
+	loggerMock.Infof("infof '%s'", value)
+	s.Equal("infof 'the-value'", loggerMock.LastCall())
+	s.Equal("infof 'the-value'", loggerMock.Call(3))
 
-	loggerMock.Warnf(warnfStr)
-	s.Equal(warnfStr, loggerMock.LastCall())
-	s.Equal(warnfStr, loggerMock.Call(4))
+	loggerMock.Warnf("warnf '%s'", value)
+	s.Equal("warnf 'the-value'", loggerMock.LastCall())
+	s.Equal("warnf 'the-value'", loggerMock.Call(4))
 
-	loggerMock.Errorf(errorfStr)
-	s.Equal(errorfStr, loggerMock.LastCall())
-	s.Equal(errorfStr, loggerMock.Call(5))
+	loggerMock.Errorf("errorf '%s'", value)
+	s.Equal("errorf 'the-value'", loggerMock.LastCall())
+	s.Equal("errorf 'the-value'", loggerMock.Call(5))
 
-	loggerMock.Fatalf(fatalfStr)
-	s.Equal(fatalfStr, loggerMock.LastCall())
-	s.Equal(fatalfStr, loggerMock.Call(6))
+	// Sprint() does not add space between arguments when both are strings.
+	loggerMock.Fatal("fatal", value)
+	s.Equal("fatalthe-value", loggerMock.LastCall())
+	s.Equal("fatalthe-value", loggerMock.Call(6))
 
-	loggerMock.Fatal(fatalStr)
-	s.Equal(fatalStr, loggerMock.LastCall())
-	s.Equal(fatalStr, loggerMock.Call(7))
+	loggerMock.Fatalf("fatalf '%s'", value)
+	s.Equal("fatalf 'the-value'", loggerMock.LastCall())
+	s.Equal("fatalf 'the-value'", loggerMock.Call(7))
 
-	loggerMock.Panicf(panicfStr)
-	s.Equal(panicfStr, loggerMock.LastCall())
-	s.Equal(panicfStr, loggerMock.Call(8))
+	loggerMock.Panicf("panicf '%s'", value)
+	s.Equal("panicf 'the-value'", loggerMock.LastCall())
+	s.Equal("panicf 'the-value'", loggerMock.Call(8))
 
 	s.Equal(9, len(loggerMock.Calls))
 
 	loggerMock.Clear()
 
 	s.Equal(0, len(loggerMock.Calls))
+}
+
+// TestLoggerMockConcurrency helps confirm that LoggerMock can be used to mock
+// logging across multiple goroutines. Run with: go test -race.
+func (s *MocksSuite) TestLoggerMockConcurrency() {
+	logger := &LoggerMock{}
+	logger.AllowAny("Infof")
+
+	const workers = 10
+	const messages = 20
+
+	// ready pauses the goroutines so they all start producing messages
+	// together.
+	ready := make(chan interface{})
+
+	wg := &sync.WaitGroup{}
+	wg.Add(workers)
+
+	produce := func(id int) {
+		<-ready
+		for i := 0; i < messages; i++ {
+			logger.Infof("message %d from %d", i, id)
+		}
+		wg.Done()
+	}
+
+	for i := 0; i < workers; i++ {
+		go produce(i)
+	}
+
+	close(ready) // ready, set, go!
+	wg.Wait()    // wait for all workers to finish producing.
+
+	s.Equal(workers*messages, len(logger.Calls))
+
+	// Check that the final message was formatted with numeric
+	// information. We don't know the identifier for that producer.
+	s.Regexp(
+		regexp.MustCompile(fmt.Sprintf(`message %d from \d+`, (messages-1))),
+		logger.Call((workers*messages)-1))
 }


### PR DESCRIPTION
Addresses some concurrency problems with `rslogtest.LoggerMock`.

```bash
MODULE=pkg/rslog/rslogtest just test -race
```

Test code may use loggers across multiple goroutines, but generally avoids inspecting the logged information while the code-under-test is running. This work changes how logged messages are recorded, which frequently occurs within multiple goroutines.

Aspects of `mock.Mock` are not concurrency-safe; this change does not address those problems.

Fixes #185