### PR TITLE
rsstorage: return original resolver err when S3 upload fails during `Put()`

### DIFF
--- a/pkg/rsstorage/servers/s3server/server_test.go
+++ b/pkg/rsstorage/servers/s3server/server_test.go
@@ -162,6 +162,8 @@ func (s *fakeS3) Upload(input *s3manager.UploadInput, ctx context.Context, optio
 		s.address = *input.Key
 
 	}
+	// If there's an upload error, copy anyway to ensure that the resolver runs
+	_, _ = io.Copy(io.Discard, input.Body)
 	return s.upload, s.uploadErr
 }
 
@@ -419,7 +421,7 @@ func (s *S3StorageServerSuite) TestPut(c *check.C) {
 	c.Assert(err, check.ErrorMatches, "upload error")
 
 	// Resolve error
-	svc.uploadErr = nil
+	svc.uploadErr = errors.New("upload error (should not be returned)")
 	resolver = func(w io.Writer) (string, string, error) {
 		return "", "", errors.New("resolver error")
 	}


### PR DESCRIPTION
When calling `StorageServer.Put()` for S3, a generic S3 upload error was always being returned when the resolver failed:

```
Something went wrong uploading to S3. You may want to check your configuration, error: ReadRequestBody: read upload data failed
caused by: Package badmissingpackage not found
```

This was making it hard to handle errors, and was also misleading because the failure occurred before even attempting to upload.

We could maybe return a wrapped error here instead? https://github.com/rstudio/platform-lib/blob/133c6151f117e37eecc4ed3edaece7e84b5a1edd/pkg/rsstorage/servers/s3server/s3_service.go#L126

But this also seems to work, returning the original resolver error if an upload failed because of the resolver.

This is for the P3M issue with invalid PyPI package index requests returning these S3 errors as unhandled 500s, rather than a 404.