### PR TITLE
feat: option to initialize storage servers without chunker

### DIFF
--- a/pkg/rsstorage/server.go
+++ b/pkg/rsstorage/server.go
@@ -95,6 +95,11 @@ type StorageServer interface {
 
 	// Base returns the base storage server in case the server is wrapped
 	Base() StorageServer
+
+	// AddChunker adds a chunker to a storage server
+	// This can be used if the storage server was initialized with
+	// NewStorageServerWithoutChunker() instead of NewStorageServer()
+	AddChunker(chunkSize uint64, waiter ChunkWaiter, notifier ChunkNotifier) StorageServer
 }
 
 type Logger interface {

--- a/pkg/rsstorage/servertest.go
+++ b/pkg/rsstorage/servertest.go
@@ -56,6 +56,10 @@ type DummyStorageServer struct {
 	GetCheckLock sync.RWMutex
 }
 
+func (f *DummyStorageServer) AddChunker(chunkSize uint64, waiter ChunkWaiter, notifier ChunkNotifier) StorageServer {
+	return f
+}
+
 func (f *DummyStorageServer) Check(dir, address string) (bool, *types.ChunksInfo, int64, time.Time, error) {
 	f.GetCheckLock.RLock()
 	defer f.GetCheckLock.RUnlock()


### PR DESCRIPTION
## Description

The goal with this change is to allow storage servers to be initialized without needing a database to be running first.

By allowing the storage server to start without the chunker, it can still use `Put()` without chunking. When `WriteChunked()` or `ReadChunked()` are needed by the storage server, it first checks that the chunker is not nil. If it is, it will throw an error.

Initial work needed for https://github.com/rstudio/package-manager/issues/13651.