### PR TITLE
debug logger: remove logger callbacks

### DIFF
--- a/pkg/rslog/NEWS.md
+++ b/pkg/rslog/NEWS.md
@@ -9,11 +9,10 @@ Unreleased
 *   Uncomment when items are available.
 -->
 
-<!--
 ### Fixed
 
-*   Uncomment when items are available.
--->
+*   Debug loggers are no longer attached to a global set of callbacks, which
+    means that those loggers are available for garbage collection.
 
 <!--
 ### Breaking

--- a/pkg/rslog/NEWS.md
+++ b/pkg/rslog/NEWS.md
@@ -1,36 +1,12 @@
 # `rslog` package 
 
-Unreleased
+pkg/rslog/v1.6.1
 --------------------------------------------------------------------------------
-
-<!--
-### New
-
-*   Uncomment when items are available.
--->
 
 ### Fixed
 
 *   Debug loggers are no longer attached to a global set of callbacks, which
     means that those loggers are available for garbage collection.
-
-<!--
-### Breaking
-
-*   Uncomment when items are available.
--->
-
-<!--
-### Deprecated / Removed
-
-*   Uncomment when items are available.
--->
-
-<!--
-### New Contributors
-
-*   Uncomment when items are available.
--->
 
 
 pkg/rslog/v1.6.0

--- a/pkg/rslog/debug.go
+++ b/pkg/rslog/debug.go
@@ -1,65 +1,95 @@
 package rslog
 
-// Copyright (C) 2022 by RStudio, PBC.
+// Copyright (C) 2025 by Posit Software, PBC.
 
 import (
 	"sync"
 )
 
+// ProductRegion is a numerical value assigned to an area of the product.
 type ProductRegion int
 
-// regionNames translates the enum region to its string equivalent. This is
-// used for display (when logging) and also when processing the configuration
-// values.
-var regionNames map[ProductRegion]string
-
-type callbacksArr []func(flag bool)
-
-var regionCallbacks = map[ProductRegion]callbacksArr{}
-var regionsEnabled = map[ProductRegion]bool{}
+// debugMutex protects access to product debug region/enabled information.
 var debugMutex sync.RWMutex
 
+// debugRegions relates a numerical product debug region to its string
+// equivalent. Used for display (when logging) and when processing
+// configuration values.
+//
+// Protected by debugMutex.
+var debugRegions map[ProductRegion]string = map[ProductRegion]string{}
+
+// debugEnabled records product debug regions which enable debug logging.
+//
+// Protected by debugMutex.
+var debugEnabled map[ProductRegion]bool = map[ProductRegion]bool{}
+
+// RegisterRegions registers product debug regions. Called once at program
+// startup.
 func RegisterRegions(regions map[ProductRegion]string) {
-	regionNames = regions
+	debugMutex.Lock()
+	defer debugMutex.Unlock()
+
+	debugRegions = regions
 }
 
+// RegionNames returns the names of all registered product debug regions.
 func RegionNames() []string {
+	debugMutex.RLock()
+	defer debugMutex.RUnlock()
+
 	var names []string
-	for _, name := range regionNames {
+	for _, name := range debugRegions {
 		names = append(names, name)
 	}
 	return names
 }
 
+// Regions returns the numerical product debug regions.
 func Regions() []ProductRegion {
+	debugMutex.RLock()
+	defer debugMutex.RUnlock()
+
 	var regions []ProductRegion
-	for r := range regionNames {
+	for r := range debugRegions {
 		regions = append(regions, r)
 	}
 	return regions
 }
 
-func RegionByName(text string) ProductRegion {
-	for region, name := range regionNames {
-		if name == text {
+// RegionByName returns the numerical product debug region associated with
+// name. Returns zero when there is no match.
+func RegionByName(name string) ProductRegion {
+	debugMutex.RLock()
+	defer debugMutex.RUnlock()
+
+	for region, region_name := range debugRegions {
+		if name == region_name {
 			return region
 		}
 	}
 	return 0
 }
 
+// RegionName returns the name associated with the numerical product debug
+// region. Returns an empty string when there is no match.
 func RegionName(region ProductRegion) string {
-	return regionNames[region]
+	debugMutex.RLock()
+	defer debugMutex.RUnlock()
+
+	return debugRegions[region]
 }
 
-// Register debug regions enabled.
-// This should be called as early as possible when starting an application.
+// InitDebugLogs registers a set of product debug regions as enabled.
+//
+// This should be called as early as possible when starting an application,
+// but after RegisterRegions.
 func InitDebugLogs(regions []ProductRegion) {
 	debugMutex.Lock()
 	defer debugMutex.Unlock()
 
 	// Reset enabled regions on each call.
-	regionsEnabled = make(map[ProductRegion]bool)
+	debugEnabled = make(map[ProductRegion]bool)
 	lgr := DefaultLogger()
 
 	// match debug log region to list
@@ -67,45 +97,34 @@ func InitDebugLogs(regions []ProductRegion) {
 		if region == 0 {
 			continue
 		}
-		regionsEnabled[region] = true
-		regionName := RegionName(region)
+		debugEnabled[region] = true
+		regionName := debugRegions[region]
 		lgr.Infof("Debug logging enabled for area: %s", regionName)
 	}
 }
 
-// Enable turns on logging for a named region. Useful in test.
+// Enable turns on debug logging for region. Useful in test.
 func Enable(region ProductRegion) {
 	debugMutex.Lock()
 	defer debugMutex.Unlock()
 
-	regionsEnabled[region] = true
-	_, ok := regionCallbacks[region]
-	if ok {
-		for _, cb := range regionCallbacks[region] {
-			cb(true)
-		}
-	}
+	debugEnabled[region] = true
 }
 
-// Disable turns on logging for a named region. Useful in test.
+// Disable turns on debug logging for region. Useful in test.
 func Disable(region ProductRegion) {
 	debugMutex.Lock()
 	defer debugMutex.Unlock()
 
-	regionsEnabled[region] = false
-	_, ok := regionCallbacks[region]
-	if ok {
-		for _, cb := range regionCallbacks[region] {
-			cb(false)
-		}
-	}
+	debugEnabled[region] = false
 }
 
-// Enabled returns true if debug logging is configured for this region.
+// Enabled returns true if debug logging is configured for region.
 func Enabled(region ProductRegion) bool {
 	debugMutex.RLock()
 	defer debugMutex.RUnlock()
-	return regionsEnabled[region]
+
+	return debugEnabled[region]
 }
 
 type DebugLogger interface {
@@ -118,86 +137,73 @@ type DebugLogger interface {
 
 type debugLogger struct {
 	Logger
-	region  ProductRegion
-	enabled bool
+	region ProductRegion
 }
 
-// NewDebugLogger returns a new logger which includes
-// the name of the debug region at every message.
+// NewDebugLogger returns a new logger which includes the name of the product
+// debug region at every message. Debugf and Tracef only occur when the
+// product debug region is enabled.
+//
+// Logging occurs only when enabled for region.
 func NewDebugLogger(region ProductRegion) *debugLogger {
 	lgr := DefaultLogger()
 
+	regionName := RegionName(region)
 	entry := lgr.WithFields(Fields{
-		"region": regionNames[region],
+		"region": regionName,
 	})
 
 	dbglgr := &debugLogger{
-		Logger:  entry,
-		region:  region,
-		enabled: Enabled(region),
+		Logger: entry,
+		region: region,
 	}
-
-	registerLoggerCb(region, dbglgr.enable)
 
 	return dbglgr
 }
 
-func registerLoggerCb(region ProductRegion, cb func(bool)) {
-	debugMutex.Lock()
-	defer debugMutex.Unlock()
-
-	regionCallbacks[region] = append(regionCallbacks[region], cb)
-}
-
-// Enabled returns true if debug logging is enabled for this rslog.
+// Enabled returns true if debug logging is enabled for the associated product
+// debug region.
 func (l *debugLogger) Enabled() bool {
 	return Enabled(l.region)
 }
 
+// Debugf logs a message when debug logging is enabled for the associated
+// product debug region.
 func (l *debugLogger) Debugf(message string, args ...interface{}) {
-	debugMutex.RLock()
-	defer debugMutex.RUnlock()
-
-	if l.enabled {
+	if l.Enabled() {
 		l.Logger.Debugf(message, args...)
 	}
 }
 
+// Tracef logs a message when debug logging is enabled for the associated
+// product debug region.
 func (l *debugLogger) Tracef(message string, args ...interface{}) {
-	debugMutex.RLock()
-	defer debugMutex.RUnlock()
-
-	if l.enabled {
+	if l.Enabled() {
 		l.Logger.Tracef(message, args...)
 	}
 }
 
-// Set fields to be logged
+// WithFields returns a new logger having additional fields. The returned
+// logger is associated with the same product debug region.
 func (l *debugLogger) WithFields(fields Fields) DebugLogger {
 	newLgr := l.Logger.WithFields(fields)
 	dbglgr := &debugLogger{
-		Logger:  newLgr,
-		region:  l.region,
-		enabled: l.enabled,
+		Logger: newLgr,
+		region: l.region,
 	}
-	registerLoggerCb(l.region, dbglgr.enable)
 	return dbglgr
 }
 
-// WithSubRegion returns a debug logger with further specificity
-// via sub_region key:value. E.g "region": "LDAP", "sub_region": "membership scanner"
+// WithSubRegion returns a debug logger having an additional "sub_region"
+// field. The returned logger is associated with the same product debug
+// region.
+//
+// Equivalent to `debugLogger.WithField("sub_region", subregion)`
 func (l *debugLogger) WithSubRegion(subregion string) DebugLogger {
 	newLgr := l.Logger.WithField("sub_region", subregion)
 	dbglgr := &debugLogger{
-		Logger:  newLgr,
-		region:  l.region,
-		enabled: l.enabled,
+		Logger: newLgr,
+		region: l.region,
 	}
-	registerLoggerCb(l.region, dbglgr.enable)
 	return dbglgr
-}
-
-// Enable or disable this region debug logging instance
-func (l *debugLogger) enable(enabled bool) {
-	l.enabled = enabled
 }

--- a/pkg/rslog/debug.go
+++ b/pkg/rslog/debug.go
@@ -63,8 +63,8 @@ func RegionByName(name string) ProductRegion {
 	debugMutex.RLock()
 	defer debugMutex.RUnlock()
 
-	for region, region_name := range debugRegions {
-		if name == region_name {
+	for region, regionName := range debugRegions {
+		if name == regionName {
 			return region
 		}
 	}

--- a/pkg/rslog/debug_test.go
+++ b/pkg/rslog/debug_test.go
@@ -1,0 +1,189 @@
+package rslog
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// Copyright (C) 2025 by Posit Software, PBC.
+
+func TestDebugSuite(t *testing.T) {
+	suite.Run(t, &DebugSuite{})
+}
+
+type DebugSuite struct {
+	suite.Suite
+
+	defaultLogger Logger
+}
+
+func (s *DebugSuite) SetupTest() {
+	s.defaultLogger = DefaultLogger()
+}
+
+func (s *DebugSuite) TearDownTest() {
+	debugMutex.Lock()
+	defer debugMutex.Unlock()
+
+	debugRegions = map[ProductRegion]string{}
+	debugEnabled = map[ProductRegion]bool{}
+
+	ReplaceDefaultLogger(s.defaultLogger)
+}
+
+func (s *DebugSuite) TestProductRegion() {
+	inputRegions := map[ProductRegion]string{
+		1: "alfa",
+		2: "bravo",
+		3: "charlie",
+	}
+	RegisterRegions(inputRegions)
+
+	// Test Regions
+	regions := Regions()
+	slices.Sort(regions)
+	assert.Equal(s.T(), regions, []ProductRegion{1, 2, 3})
+
+	// Test RegionNames
+	names := RegionNames()
+	slices.Sort(names)
+	assert.Equal(s.T(), names, []string{"alfa", "bravo", "charlie"})
+
+	// Test RegionName
+	assert.Equal(s.T(), RegionName(1), "alfa")
+	assert.Equal(s.T(), RegionName(2), "bravo")
+	assert.Equal(s.T(), RegionName(3), "charlie")
+	assert.Equal(s.T(), RegionName(4), "")
+
+	// Test RegionByName
+	assert.Equal(s.T(), RegionByName("alfa"), ProductRegion(1))
+	assert.Equal(s.T(), RegionByName("bravo"), ProductRegion(2))
+	assert.Equal(s.T(), RegionByName("charlie"), ProductRegion(3))
+	assert.Equal(s.T(), RegionByName("delta"), ProductRegion(0))
+
+	// All registered regions are initially disabled. Test Enabled()
+	assert.Equal(s.T(), Enabled(1), false)
+	assert.Equal(s.T(), Enabled(2), false)
+	assert.Equal(s.T(), Enabled(3), false)
+
+	// Enable a subset. Test InitDebugLogs
+	InitDebugLogs([]ProductRegion{1, 3})
+
+	assert.Equal(s.T(), Enabled(1), true)
+	assert.Equal(s.T(), Enabled(2), false)
+	assert.Equal(s.T(), Enabled(3), true)
+
+	// Flip things around. Test Enable/Disable.
+	Disable(1)
+	Enable(2)
+	Disable(3)
+
+	assert.Equal(s.T(), Enabled(1), false)
+	assert.Equal(s.T(), Enabled(2), true)
+	assert.Equal(s.T(), Enabled(3), false)
+}
+
+func (s *DebugSuite) TestDebugLogger() {
+	lgr := NewCapturingLogger(CapturingLoggerOptions{
+		Level:        TraceLevel,
+		WithMetadata: false,
+	})
+	ReplaceDefaultLogger(lgr)
+
+	RegisterRegions(map[ProductRegion]string{
+		1: "alfa",
+		2: "bravo",
+		3: "charlie",
+	})
+
+	parent := NewDebugLogger(1)
+	assert.Equal(s.T(), parent, &debugLogger{
+		Logger: lgr.WithFields(Fields{
+			"region": "alfa",
+		}),
+		region: 1,
+	})
+	subregion := parent.WithSubRegion("drinks")
+	assert.Equal(s.T(), subregion, &debugLogger{
+		Logger: lgr.WithFields(Fields{
+			"region":     "alfa",
+			"sub_region": "drinks",
+		}),
+		region: 1,
+	})
+	fielded := subregion.WithFields(Fields{
+		"kind": "coffee",
+	})
+	assert.Equal(s.T(), fielded, &debugLogger{
+		Logger: lgr.WithFields(Fields{
+			"region":     "alfa",
+			"sub_region": "drinks",
+			"kind":       "coffee",
+		}),
+		region: 1,
+	})
+
+	// Loggers all follow the enabled state for the region.
+
+	// Initially disabled.
+	assert.Equal(s.T(), parent.Enabled(), false)
+	assert.Equal(s.T(), subregion.Enabled(), false)
+	assert.Equal(s.T(), fielded.Enabled(), false)
+
+	// Still disabled when some other region is enabled.
+	Enable(2)
+	assert.Equal(s.T(), parent.Enabled(), false)
+	assert.Equal(s.T(), subregion.Enabled(), false)
+	assert.Equal(s.T(), fielded.Enabled(), false)
+
+	// Enabled when the region is enabled.
+	Enable(1)
+	assert.Equal(s.T(), parent.Enabled(), true)
+	assert.Equal(s.T(), subregion.Enabled(), true)
+	assert.Equal(s.T(), fielded.Enabled(), true)
+
+	// Still enabled when that other region is disabled
+	Disable(2)
+	assert.Equal(s.T(), parent.Enabled(), true)
+	assert.Equal(s.T(), subregion.Enabled(), true)
+	assert.Equal(s.T(), fielded.Enabled(), true)
+
+	// Disabled when the region is disabled again.
+	Disable(1)
+	assert.Equal(s.T(), parent.Enabled(), false)
+	assert.Equal(s.T(), subregion.Enabled(), false)
+	assert.Equal(s.T(), fielded.Enabled(), false)
+
+	// When disabled, no messages from debug/trace.
+	lgr.Clear()
+	parent.Debugf("debug disabled from parent")
+	subregion.Debugf("debug disabled from subregion")
+	fielded.Debugf("debug disabled from fielded")
+	parent.Tracef("trace disabled from parent")
+	subregion.Tracef("trace disabled from subregion")
+	fielded.Tracef("trace disabled from fielded")
+	assert.Empty(s.T(), lgr.Messages())
+
+	// When enabled, messages from debug/trace.
+	lgr.Clear()
+	Enable(1)
+	parent.Debugf("debug enabled from parent")
+	subregion.Debugf("debug enabled from subregion")
+	fielded.Debugf("debug enabled from fielded")
+	parent.Tracef("trace enabled from parent")
+	subregion.Tracef("trace enabled from subregion")
+	fielded.Tracef("trace enabled from fielded")
+	assert.Equal(s.T(), lgr.Messages(), []string{
+		"debug enabled from parent",
+		"debug enabled from subregion",
+		"debug enabled from fielded",
+		"trace enabled from parent",
+		"trace enabled from subregion",
+		"trace enabled from fielded",
+	})
+}

--- a/pkg/rslog/debug_test.go
+++ b/pkg/rslog/debug_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// Copyright (C) 2025 by Posit Software, PBC.
-
 func TestDebugSuite(t *testing.T) {
 	suite.Run(t, &DebugSuite{})
 }

--- a/pkg/rslog/logger_test.go
+++ b/pkg/rslog/logger_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/check.v1"
 )
 
-func TestPackage(t *testing.T) {
+func TestLoggerSuite(t *testing.T) {
 	suite.Run(t, &LoggerSuite{})
 }
 
@@ -200,7 +199,7 @@ func (s *LoggerSuite) TestBuildPreamble() {
 			expected: "[first: 42; second: 13] ",
 		},
 	} {
-		s.Equal(BuildPreamble(each.args...), each.expected, check.Commentf(each.description))
+		s.Equal(BuildPreamble(each.args...), each.expected, each.description)
 	}
 }
 

--- a/scripts/header-check.sh
+++ b/scripts/header-check.sh
@@ -4,7 +4,7 @@
 __EXITCODE=0
 
 # Matches a copyright
-COPYRIGHT_REGEX="// Copyright \(C\) [0-9]{4} by RStudio, PBC"
+COPYRIGHT_REGEX="// Copyright \(C\) [0-9]{4} by (RStudio|Posit Software), PBC"
 
 # Collect a list of go files.
 for gofile in $(find . -name *.go); do


### PR DESCRIPTION
All debug logger instances were previously attached to a global set of callbacks. This was done so loggers could be informed if they were ever enabled dynamically. Unfortunately, loggers were never removed from this set of callbacks, which meant that those loggers could never be reclaimed by the garbage collector. Debug loggers are often constructed as the program runs, adding fields and values to assist with tracing. This meant that programs often did not have a static set of loggers, but were always creating new debug loggers, which were always seen as live objects.

Now, debug loggers always ask their enabled status from the map tracking enabled state. This incurs the cost of a mutex-read lock and map lookup at runtime.

This change is associated with Connect issue 29616