### PR TITLE
chore: remove warn log for slow queue because it is misleading

### DIFF
--- a/pkg/rsqueue/impls/database/queue.go
+++ b/pkg/rsqueue/impls/database/queue.go
@@ -351,9 +351,6 @@ func (q *DatabaseQueue) Get(ctx context.Context, maxPriority uint64, maxPriority
 		} else {
 			slog.Debug(fmt.Sprintf("Queue Get() returned in %d ms", t))
 		}
-		if t/1000 >= 60 {
-			slog.Warn("Queue Get() process slow", "time", fmt.Sprintf("%vs", t/1000))
-		}
 	}(queueWork)
 	if err != sql.ErrNoRows {
 		q.measureDequeue(ctx, queueWork, err)


### PR DESCRIPTION
Removing the slow queue warn log added in https://github.com/rstudio/platform-lib/pull/228. We have found this to be very noisy and misleading. Upon further investigation, we found the timer starts at the beginning of the function call and then is designed to wait and loop until there is actual work. On systems that sit idle for a while and then do work, this leads to lots of logs like this:
```
2025/12/17 21:52:52 WARN Queue Get() process slow time: "239s"
2025/12/17 21:53:52 WARN Queue Get() process slow time: "60s"
2025/12/17 21:59:52 WARN Queue Get() process slow time: "359s"
2025/12/17 22:05:52 WARN Queue Get() process slow time: "359s"
2025/12/17 22:11:52 WARN Queue Get() process slow time: "359s"
2025/12/17 22:16:52 WARN Queue Get() process slow time: "300s"
2025/12/17 22:22:52 WARN Queue Get() process slow time: "359s"
2025/12/17 22:28:52 WARN Queue Get() process slow time: "359s"
```

We should rework the timing to only count when work is actually running. For now we will remove it and revisit updating the timer more accurately later, tracked in this issue: https://github.com/rstudio/package-manager/issues/16800

More discussion about this issue and investigation here: https://github.com/rstudio/package-manager/issues/16794

---


Ref https://github.com/rstudio/package-manager/issues/16794