### PR TITLE
fix: do not attempt to cache object when there is an error

### DIFF
--- a/pkg/rscache/memory_backed_file_cache.go
+++ b/pkg/rscache/memory_backed_file_cache.go
@@ -89,7 +89,7 @@ func (mbfc *MemoryBackedFileCache) Get(ctx context.Context, resolver ResolverSpe
 
 	ptr = mbfc.fc.Get(ctx, resolver)
 
-	if resolver.CacheInMemory && mbfc.mc != nil && mbfc.mc.Enabled() && ptr.GetSize() < mbfc.maxMemoryPerObject {
+	if resolver.CacheInMemory && mbfc.mc != nil && mbfc.mc.Enabled() && ptr.Err == nil && ptr.GetSize() < mbfc.maxMemoryPerObject {
 		err = mbfc.mc.Put(address, ptr)
 		if err != nil {
 			slog.Debug(fmt.Sprintf("error caching to memory: %s", err.Error()))


### PR DESCRIPTION
I'm seeing logs related to gob caching:          

```
2025/12/22 13:14:48 DEBUG source=memory_backed_file_cache.go:95 error caching to memory: gob: type not registered for interface: errors.errorString
2025/12/22 13:14:51 DEBUG source=memory_backed_file_cache.go:95 error caching to memory: gob: type not registered sfor interface: fmt.wrapError
```

These gob errors seem to be related to context cancellation. When the context is canceled:                    
1. `mbfc.fc.Get(ctx, resolver)` returns a `CacheReturn` with `Err` set to the context cancellation error
2. The code then tries to cache this result in memory using gob encoding
3. Gob can't encode Go's error types (`errors.errorString`, `fmt.wrapError`) because they're not registered
4. Hence the `"gob: type not registered for interface"` error

There is currently no harm done because it only logs a debug error when it can't cache the error, but we should not even attempt to cache results that have errors.

Ref https://github.com/rstudio/package-manager/issues/16809