### PR TITLE
Respect context in file cache `Get()` and `Head()`

### DIFF
--- a/pkg/rscache/file.go
+++ b/pkg/rscache/file.go
@@ -196,11 +196,8 @@ func (o *fileCache) Head(ctx context.Context, resolver ResolverSpec) (size int64
 		for {
 			select {
 			case <-ctx.Done():
+				err = ctx.Err()
 				return
-			default:
-
-			}
-			select {
 			case err = <-errCh:
 				if err != nil {
 					return
@@ -292,6 +289,9 @@ func (o *fileCache) Get(ctx context.Context, resolver ResolverSpec) (value *Cach
 		// Wait
 		for {
 			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+				return
 			case err = <-errCh:
 				if err != nil {
 					return


### PR DESCRIPTION
For https://github.com/rstudio/package-manager/issues/16862

Fix an issue with the file cache's `Get()` and `Head()` not respecting context, e.g. not properly timing out given a context with timeout.