### PR TITLE
Finish migrating platform-lib to slog

### DIFF
--- a/pkg/rscache/file.go
+++ b/pkg/rscache/file.go
@@ -102,9 +102,9 @@ func (o *fileCache) retryingGet(ctx context.Context, dir, address string, get fu
 	// Preemptive get attempt
 	if flushingGet() {
 		if flushed == 0 {
-			slog.Log(ctx, LevelTrace, fmt.Sprintf("Found cached item at address '%s' immediately", address))
+			slog.Log(ctx, LevelTrace, "Found cached item immediately", "address", address)
 		} else {
-			slog.Log(ctx, LevelTrace, fmt.Sprintf("Found cached item at address '%s' after one flush", address))
+			slog.Log(ctx, LevelTrace, "Found cached item after one flush", "address", address)
 		}
 		return true
 	}
@@ -184,7 +184,7 @@ func (o *fileCache) Head(ctx context.Context, resolver ResolverSpec) (size int64
 		err = o.queue.AddressedPush(ctx, resolver.Priority, resolver.GroupId, resolver.Address(), resolver.Work)
 		if o.duplicateMatcher.IsDuplicate(err) {
 			// Do nothing since; someone else has already inserted the work we need.
-			slog.Debug(fmt.Sprintf("FileCache: duplicate address push for '%s'", resolver.Address()))
+			slog.Debug("FileCache: duplicate address push", "address", resolver.Address())
 		} else if err != nil {
 			return
 		}
@@ -205,7 +205,7 @@ func (o *fileCache) Head(ctx context.Context, resolver ResolverSpec) (size int64
 				if o.retryingGet(ctx, resolver.Dir(), resolver.Address(), head) {
 					return
 				} else {
-					slog.Debug(fmt.Sprintf("error: FileCache reported address '%s' complete, but item was not found in cache", resolver.Address()))
+					slog.Debug("error: FileCache reported address complete, but item was not found in cache", "address", resolver.Address())
 					err = fmt.Errorf("error: FileCache reported address '%s' complete, but item was not found in cache", resolver.Address())
 					return
 				}
@@ -274,7 +274,7 @@ func (o *fileCache) Get(ctx context.Context, resolver ResolverSpec) (value *Cach
 		err = o.queue.AddressedPush(ctx, resolver.Priority, resolver.GroupId, address, resolver.Work)
 		if o.duplicateMatcher.IsDuplicate(err) {
 			// Do nothing since; someone else has already inserted the work we need.
-			slog.Debug(fmt.Sprintf("FileCache: duplicate address push for '%s'", address))
+			slog.Debug("FileCache: duplicate address push", "address", address)
 		} else if err != nil {
 			value = &CacheReturn{
 				Err:      err,

--- a/pkg/rscache/internal/integration_test/memory_test.go
+++ b/pkg/rscache/internal/integration_test/memory_test.go
@@ -9,7 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -217,7 +217,7 @@ func (s *MemoryCacheIntegrationSuite) TestInMemoryCaching(c *check.C) {
 
 	// Create an in-memory cache that is just large enough to hold 64 entries
 	maxCost := entrySize * 64
-	log.Printf("Creating cache with MaxCost=%d", maxCost)
+	slog.Info(fmt.Sprintf("Creating cache with MaxCost=%d", maxCost))
 	rc, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1000,
 		MaxCost:     maxCost,

--- a/pkg/rscache/internal/integration_test/memory_test.go
+++ b/pkg/rscache/internal/integration_test/memory_test.go
@@ -217,7 +217,7 @@ func (s *MemoryCacheIntegrationSuite) TestInMemoryCaching(c *check.C) {
 
 	// Create an in-memory cache that is just large enough to hold 64 entries
 	maxCost := entrySize * 64
-	slog.Info(fmt.Sprintf("Creating cache with MaxCost=%d", maxCost))
+	slog.Info("Creating cache", "maxCost", maxCost)
 	rc, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1000,
 		MaxCost:     maxCost,

--- a/pkg/rscache/memory_backed_file_cache.go
+++ b/pkg/rscache/memory_backed_file_cache.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"time"
@@ -92,7 +91,7 @@ func (mbfc *MemoryBackedFileCache) Get(ctx context.Context, resolver ResolverSpe
 	if resolver.CacheInMemory && mbfc.mc != nil && mbfc.mc.Enabled() && ptr.Err == nil && ptr.GetSize() < mbfc.maxMemoryPerObject {
 		err = mbfc.mc.Put(address, ptr)
 		if err != nil {
-			slog.Debug(fmt.Sprintf("error caching to memory: %s", err.Error()))
+			slog.Debug("error caching to memory", "error", err)
 		}
 	}
 	return *ptr
@@ -131,7 +130,7 @@ func (mbfc *MemoryBackedFileCache) GetObject(ctx context.Context, resolver Resol
 	if resolver.CacheInMemory && mbfc.mc != nil && mbfc.mc.Enabled() && ptr.GetSize() < mbfc.maxMemoryPerObject {
 		err = mbfc.mc.Put(address, ptr)
 		if err != nil {
-			slog.Debug(fmt.Sprintf("error caching to memory: %s", err.Error()))
+			slog.Debug("error caching to memory", "error", err)
 		}
 	}
 

--- a/pkg/rselection/impls/pgx/follower.go
+++ b/pkg/rselection/impls/pgx/follower.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"log/slog"
 	"time"
 
@@ -122,13 +121,13 @@ func (p *PgxFollower) handleNotify(ctx context.Context, cn *electiontypes.Cluste
 	resp := electiontypes.NewClusterPingResponse(p.address, cn.SrcAddr, p.awb.IP())
 	b, err := json.Marshal(resp)
 	if err != nil {
-		log.Printf("Error marshaling notification to JSON: %s", err)
+		slog.Error(fmt.Sprintf("Error marshaling notification to JSON: %s", err))
 		return
 	}
 	slog.Log(ctx, LevelTrace, fmt.Sprintf("Follower %s responding to ping from leader %s", p.address, cn.SrcAddr))
 	err = p.notify.Notify(ctx, p.chLeader, b)
 	if err != nil {
-		log.Printf("Follower error responding to leader ping: %s", err)
+		slog.Error(fmt.Sprintf("Follower error responding to leader ping: %s", err))
 	}
 }
 
@@ -138,7 +137,7 @@ func (p *PgxFollower) requestLeader(ctx context.Context) {
 		now := time.Now()
 		// Limit how often this message logs to avoid too much spam
 		if p.lastRequestLeaderErr.IsZero() || p.lastRequestLeaderErr.Add(5*time.Minute).Before(now) {
-			log.Printf("Error pushing leader assumption work to queue: %s", err)
+			slog.Error(fmt.Sprintf("Error pushing leader assumption work to queue: %s", err))
 			p.lastRequestLeaderErr = now
 		}
 	}

--- a/pkg/rselection/impls/pgx/follower.go
+++ b/pkg/rselection/impls/pgx/follower.go
@@ -5,7 +5,6 @@ package pgxelection
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -104,7 +103,7 @@ func (p *PgxFollower) Follow(ctx context.Context) (result FollowResult) {
 		case <-timeout.C:
 			// Follower has received no pings for the timeout duration. It is time to
 			// ask for a new leader.
-			slog.Debug(fmt.Sprintf("Follower '%s' ping receipt timeout. Requesting a new leader", p.address))
+			slog.Debug("Follower ping receipt timeout. Requesting a new leader", "address", p.address)
 			go p.requestLeader(ctx)
 		}
 		return
@@ -121,13 +120,13 @@ func (p *PgxFollower) handleNotify(ctx context.Context, cn *electiontypes.Cluste
 	resp := electiontypes.NewClusterPingResponse(p.address, cn.SrcAddr, p.awb.IP())
 	b, err := json.Marshal(resp)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Error marshaling notification to JSON: %s", err))
+		slog.Error("Error marshaling notification to JSON", "error", err)
 		return
 	}
-	slog.Log(ctx, LevelTrace, fmt.Sprintf("Follower %s responding to ping from leader %s", p.address, cn.SrcAddr))
+	slog.Log(ctx, LevelTrace, "Follower responding to ping from leader", "follower", p.address, "leader", cn.SrcAddr)
 	err = p.notify.Notify(ctx, p.chLeader, b)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Follower error responding to leader ping: %s", err))
+		slog.Error("Follower error responding to leader ping", "error", err)
 	}
 }
 
@@ -137,7 +136,7 @@ func (p *PgxFollower) requestLeader(ctx context.Context) {
 		now := time.Now()
 		// Limit how often this message logs to avoid too much spam
 		if p.lastRequestLeaderErr.IsZero() || p.lastRequestLeaderErr.Add(5*time.Minute).Before(now) {
-			slog.Error(fmt.Sprintf("Error pushing leader assumption work to queue: %s", err))
+			slog.Error("Error pushing leader assumption work to queue", "error", err)
 			p.lastRequestLeaderErr = now
 		}
 	}

--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -3,7 +3,6 @@ package broadcaster
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/rstudio/platform-lib/v3/pkg/rsnotify/listener"
@@ -97,7 +96,7 @@ func (b *NotificationBroadcaster) broadcast() {
 			}
 		case err, more := <-b.errs:
 			if more {
-				slog.Error(fmt.Sprintf("Received error on queue addressed work notification channel: %s", err))
+				slog.Error("Received error on queue addressed work notification channel", "error", err)
 			}
 		case sink := <-b.subscribe:
 			sinks = append(sinks, sink)

--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -3,7 +3,8 @@ package broadcaster
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 
 	"github.com/rstudio/platform-lib/v3/pkg/rsnotify/listener"
 )
@@ -96,7 +97,7 @@ func (b *NotificationBroadcaster) broadcast() {
 			}
 		case err, more := <-b.errs:
 			if more {
-				log.Printf("Received error on queue addressed work notification channel: %s", err)
+				slog.Error(fmt.Sprintf("Received error on queue addressed work notification channel: %s", err))
 			}
 		case sink := <-b.subscribe:
 			sinks = append(sinks, sink)

--- a/pkg/rsnotify/listeners/local/locallistener.go
+++ b/pkg/rsnotify/listeners/local/locallistener.go
@@ -5,7 +5,6 @@ package local
 import (
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"sync"
 	"time"
@@ -97,17 +96,17 @@ func (l *Listener) wait(msgs chan listener.Notification, errs chan error, stop c
 	// channel is signaled or closed.
 	//
 	// This path is currently run only in the unit tests, so I included some
-	// `log.Printf` usages are for the benefit of verbose testing output.
+	// `slog.Debug` usages are for the benefit of verbose testing output.
 	if l.deferredStart != nil {
 		// First, wait for the test to notify that it's time to start listening. This
 		// gives us a chance to set up a deadlock condition in the test.
-		log.Printf("Waiting for test notification to start")
+		slog.Debug("Waiting for test notification to start")
 		<-l.deferredStart
 		// Next, simulate an unexpected stop by waiting for a stop signal after
 		// which we return without ever receiving from the `l.items` channel.
-		log.Printf("Proceeding with wait by waiting for stop signal")
+		slog.Debug("Proceeding with wait by waiting for stop signal")
 		<-stop
-		log.Printf("Stopped. Returning without receiving from l.items.")
+		slog.Debug("Stopped. Returning without receiving from l.items.")
 		return
 	}
 	for {

--- a/pkg/rsnotify/listeners/local/locallistener.go
+++ b/pkg/rsnotify/listeners/local/locallistener.go
@@ -4,7 +4,6 @@ package local
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -81,10 +80,10 @@ func (l *Listener) Listen() (chan listener.Notification, chan error, error) {
 
 func (l *Listener) listen(msgs chan listener.Notification, errs chan error) {
 	defer func() {
-		slog.Debug(fmt.Sprintf("Stopping listener..."))
+		slog.Debug("Stopping listener...")
 		l.items = nil
 		close(l.stop)
-		slog.Debug(fmt.Sprintf("Stopped."))
+		slog.Debug("Stopped.")
 	}()
 
 	l.wait(msgs, errs, l.stop)
@@ -112,11 +111,11 @@ func (l *Listener) wait(msgs chan listener.Notification, errs chan error, stop c
 	for {
 		select {
 		case <-stop:
-			slog.Debug(fmt.Sprintf("Stopping wait"))
+			slog.Debug("Stopping wait")
 			return
 		case i := <-l.items:
 			if msg, ok := i.(listener.Notification); ok {
-				slog.Debug(fmt.Sprintf("Received message: %s. Sending to buffered channel with current size %d", msg.Guid(), len(msgs)))
+				slog.Debug("Received message. Sending to buffered channel", "guid", msg.Guid(), "channelSize", len(msgs))
 				msgs <- msg
 			} else {
 				errs <- ErrNotNotificationType
@@ -128,13 +127,13 @@ func (l *Listener) wait(msgs chan listener.Notification, errs chan error, stop c
 func (l *Listener) Stop() {
 	if l.stop != nil {
 		// Signal to stop
-		slog.Debug(fmt.Sprintf("Signaling stop channel to stop..."))
+		slog.Debug("Signaling stop channel to stop...")
 		l.stop <- true
 
 		// Wait for stop
-		slog.Debug(fmt.Sprintf("Waiting for stop channel to close..."))
+		slog.Debug("Waiting for stop channel to close...")
 		<-l.stop
-		slog.Debug(fmt.Sprintf("Stop channel for %s closed.", l.guid))
+		slog.Debug("Stop channel closed.", "guid", l.guid)
 		l.stop = nil
 
 		// Remove from provider
@@ -168,7 +167,7 @@ func (l *ListenerProvider) notify(channel string, n interface{}, prevMissedItems
 		notifyTxt = "renotify"
 	}
 
-	slog.Debug(fmt.Sprintf("Notify called with type=%s on %d listeners", notifyTxt, len(l.listeners)))
+	slog.Debug("Notify called", "type", notifyTxt, "listenerCount", len(l.listeners))
 	for _, ll := range l.listeners {
 		var needNotify bool
 		if prevMissedItems == nil {
@@ -183,7 +182,7 @@ func (l *ListenerProvider) notify(channel string, n interface{}, prevMissedItems
 			// There's a chance that `ll.items` could be non-nil, but not receiving. Timeout
 			// to prevent deadlock, but keep trying until we're sure that the listener is
 			// closed.
-			slog.Debug(fmt.Sprintf("Ready to %s internal items with guid %s for channel %s %s: %+v", notifyTxt, notifyGuid, ll.guid, channel, n))
+			slog.Debug("Ready to notify internal items", "type", notifyTxt, "notifyGuid", notifyGuid, "listenerGuid", ll.guid, "channel", channel, "notification", n)
 			func() {
 				// It's important to create a ticker and stop it so it doesn't leak. This has the potential to be called
 				// thousands of times in a relatively short period on a busy server, so timer leaks can result in
@@ -192,9 +191,9 @@ func (l *ListenerProvider) notify(channel string, n interface{}, prevMissedItems
 				defer timeout.Stop()
 				select {
 				case ll.items <- n:
-					slog.Debug(fmt.Sprintf("Done with %s in local listener with guid %s for channel %s: %+v", notifyTxt, notifyGuid, channel, n))
+					slog.Debug("Done with notify in local listener", "type", notifyTxt, "notifyGuid", notifyGuid, "channel", channel, "notification", n)
 				case <-timeout.C:
-					slog.Debug(fmt.Sprintf("Timeout during %s for listener %s/%s with guid %s for channel %s: %+v", notifyTxt, ll.guid, ll.name, notifyGuid, channel, n))
+					slog.Debug("Timeout during notify", "type", notifyTxt, "listenerGuid", ll.guid, "listenerName", ll.name, "notifyGuid", notifyGuid, "channel", channel, "notification", n)
 					// Record the timed-out notification in the `missed` map so we can retry it
 					missed[ll.guid] = notifyGuid
 				}
@@ -211,7 +210,7 @@ func (l *ListenerProvider) notify(channel string, n interface{}, prevMissedItems
 	// provider after the mutex is again locked by the recursive call to `notify` will be
 	// attempted again as needed.
 	if len(missed) > 0 {
-		slog.Debug(fmt.Sprintf("calling l.notify for %+v with guid %s for %d missed items on channel %s", n, notifyGuid, len(missed), channel))
+		slog.Debug("calling l.notify for missed items", "notification", n, "notifyGuid", notifyGuid, "missedCount", len(missed), "channel", channel)
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 		// If logging is enabled, periodically record notifications that are still waiting
@@ -221,13 +220,13 @@ func (l *ListenerProvider) notify(channel string, n interface{}, prevMissedItems
 			for {
 				select {
 				case <-tick.C:
-					slog.Debug(fmt.Sprintf("still waiting on l.notify for +%v with guid %s on channel %s", n, notifyGuid, channel))
+					slog.Debug("still waiting on l.notify", "notification", n, "notifyGuid", notifyGuid, "channel", channel)
 				case <-stop:
 					return
 				}
 			}
 		}(stopCh)
 		l.notify(channel, n, missed)
-		slog.Debug(fmt.Sprintf("completed calling l.notify for %d missed items with guid %s on channel %s", len(missed), notifyGuid, channel))
+		slog.Debug("completed calling l.notify for missed items", "missedCount", len(missed), "notifyGuid", notifyGuid, "channel", channel)
 	}
 }

--- a/pkg/rsnotify/listeners/local/locallistener_test.go
+++ b/pkg/rsnotify/listeners/local/locallistener_test.go
@@ -62,7 +62,7 @@ func (s *LocalNotifySuite) TestNotifications(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				testError = e
 				return
 			}
@@ -109,7 +109,7 @@ func (s *LocalNotifySuite) TestNotifications(c *check.C) {
 				c.Assert(i.(*listener.TestNotification).Val, check.Equals, "second-test")
 				return
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -125,7 +125,7 @@ func (s *LocalNotifySuite) TestNotifications(c *check.C) {
 				c.Assert(i.(*listener.TestNotification).Val, check.Equals, "second-test-bb")
 				return
 			case e := <-errs2:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -190,7 +190,7 @@ func (s *LocalNotifySuite) TestNotificationsBlock(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				testError = e
 				return
 			}
@@ -251,7 +251,7 @@ func (s *LocalNotifySuite) TestNotificationsErrs(c *check.C) {
 				}
 				count++
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				if e.Error() != "a notification must be of type listener.Notification" {
 					testError = fmt.Errorf("invalid error received: %s", e.Error())
 					return

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net"
 	"reflect"
@@ -39,16 +38,16 @@ func (p *PgxIPReporter) IP() string {
 		var ipNet net.IPNet
 		err := p.pool.QueryRow(context.Background(), query).Scan(&ipNet)
 		if err != nil {
-			log.Printf("Unable to determine client IP with inet_client_addr(). %s", err)
+			slog.Error(fmt.Sprintf("Unable to determine client IP with inet_client_addr(). %s", err))
 			return ip
 		}
 		if ipNet.IP != nil {
 			ip = ipNet.IP.String()
 		} else {
-			log.Printf("Unable to determine client IP with inet_client_addr().")
+			slog.Error("Unable to determine client IP with inet_client_addr().")
 		}
 	} else {
-		log.Printf("Invalid pool")
+		slog.Error("Invalid pool")
 	}
 	return ip
 }
@@ -219,7 +218,7 @@ func (l *PgxListener) acquire(ready chan struct{}) (err error) {
 	select {
 	case <-ready:
 		// Already closed. This means that we are reconnecting
-		log.Printf("successfully reconnected listener %s", l.name)
+		slog.Info(fmt.Sprintf("successfully reconnected listener %s", l.name))
 	default:
 		// Close the `ready` channel to signal that `Listen()` can return.
 		close(ready)

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener.go
@@ -38,7 +38,7 @@ func (p *PgxIPReporter) IP() string {
 		var ipNet net.IPNet
 		err := p.pool.QueryRow(context.Background(), query).Scan(&ipNet)
 		if err != nil {
-			slog.Error(fmt.Sprintf("Unable to determine client IP with inet_client_addr(). %s", err))
+			slog.Error("Unable to determine client IP with inet_client_addr()", "error", err)
 			return ip
 		}
 		if ipNet.IP != nil {
@@ -218,7 +218,7 @@ func (l *PgxListener) acquire(ready chan struct{}) (err error) {
 	select {
 	case <-ready:
 		// Already closed. This means that we are reconnecting
-		slog.Info(fmt.Sprintf("successfully reconnected listener %s", l.name))
+		slog.Info("successfully reconnected listener", "name", l.name)
 	default:
 		// Close the `ready` channel to signal that `Listen()` can return.
 		close(ready)
@@ -326,10 +326,10 @@ func (l *PgxListener) notify(n *pgconn.Notification, errs chan error, items chan
 }
 
 func (l *PgxListener) Stop() {
-	slog.Debug(fmt.Sprintf("Signaling context to cancel listener %s", l.name))
+	slog.Debug("Signaling context to cancel listener", "name", l.name)
 	l.cancel()
 	// Wait for stop
-	slog.Debug(fmt.Sprintf("Waiting for listener %s to stop...", l.name))
+	slog.Debug("Waiting for listener to stop...", "name", l.name)
 	<-l.exit
 
 	// Clean up connection
@@ -339,5 +339,5 @@ func (l *PgxListener) Stop() {
 		l.conn = nil
 	}
 
-	slog.Debug(fmt.Sprintf("Listener %s closed.", l.name))
+	slog.Debug("Listener closed.", "name", l.name)
 }

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
@@ -4,7 +4,6 @@ package postgrespgx
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -170,7 +169,7 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -244,7 +243,7 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 				c.Assert(i.(*testNotification).Val, check.Equals, "second-test")
 				return
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -424,7 +423,7 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}

--- a/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespgx/pgxlistener_test.go
@@ -4,7 +4,8 @@ package postgrespgx
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -169,7 +170,7 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -243,7 +244,7 @@ func (s *PgxNotifySuite) TestNotificationsNormal(c *check.C) {
 				c.Assert(i.(*testNotification).Val, check.Equals, "second-test")
 				return
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -335,7 +336,7 @@ func (s *PgxNotifySuite) TestNotificationsErrors(c *check.C) {
 		for {
 			select {
 			case <-data:
-				log.Printf("unexpected good data")
+				slog.Error("unexpected good data")
 				c.FailNow()
 			case e := <-errs:
 				errStr := e.Error()
@@ -413,7 +414,7 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 		defer close(done)
 		// Block a while before receiving each message
 		<-blocker
-		log.Printf("Unblocked. Starting to receive.")
+		slog.Info("Unblocked. Starting to receive.")
 		for {
 			select {
 			case i := <-data:
@@ -423,7 +424,7 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -441,7 +442,7 @@ func (s *PgxNotifySuite) TestNotificationsBlock(c *check.C) {
 	}
 
 	// Block receiving any notifications until all have been sent
-	log.Printf("All messages have been sent")
+	slog.Info("All messages have been sent")
 	close(blocker)
 
 	// Wait for test to complete

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"log/slog"
 	"reflect"
 	"time"
@@ -141,7 +140,7 @@ func (l *PqListener) acquire(ready chan struct{}) (err error) {
 	select {
 	case <-ready:
 		// Already closed. This means that we are reconnecting
-		log.Printf("successfully reconnected listener %s", l.name)
+		slog.Info(fmt.Sprintf("successfully reconnected listener %s", l.name))
 	default:
 		// Close the `ready` channel to signal that `Listen()` can return.
 		close(ready)

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener.go
@@ -140,7 +140,7 @@ func (l *PqListener) acquire(ready chan struct{}) (err error) {
 	select {
 	case <-ready:
 		// Already closed. This means that we are reconnecting
-		slog.Info(fmt.Sprintf("successfully reconnected listener %s", l.name))
+		slog.Info("successfully reconnected listener", "name", l.name)
 	default:
 		// Close the `ready` channel to signal that `Listen()` can return.
 		close(ready)
@@ -196,10 +196,10 @@ func (l *PqListener) notify(n *pq.Notification, errs chan error, items chan list
 }
 
 func (l *PqListener) Stop() {
-	slog.Debug(fmt.Sprintf("Signaling context to cancel listener %s", l.name))
+	slog.Debug("Signaling context to cancel listener", "name", l.name)
 	l.cancel()
 	// Wait for stop
-	slog.Debug(fmt.Sprintf("Waiting for listener %s to stop...", l.name))
+	slog.Debug("Waiting for listener to stop...", "name", l.name)
 	<-l.exit
 
 	// Clean up connection
@@ -209,5 +209,5 @@ func (l *PqListener) Stop() {
 		l.conn = nil
 	}
 
-	slog.Debug(fmt.Sprintf("Listener %s closed.", l.name))
+	slog.Debug("Listener closed.", "name", l.name)
 }

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
@@ -3,7 +3,8 @@ package postgrespq
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"log"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -136,7 +137,7 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -188,7 +189,7 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 				c.Assert(i.(*testNotification).Val, check.Equals, "second-test")
 				return
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -253,7 +254,7 @@ func (s *PqNotifySuite) TestNotificationsErrors(c *check.C) {
 		for {
 			select {
 			case <-data:
-				log.Printf("unexpected good data")
+				slog.Error("unexpected good data")
 				c.FailNow()
 			case e := <-errs:
 				errStr := e.Error()
@@ -318,7 +319,7 @@ func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
 		defer close(done)
 		// Block a while before receiving each message
 		<-blocker
-		log.Printf("Unblocked. Starting to receive.")
+		slog.Info("Unblocked. Starting to receive.")
 		for {
 			select {
 			case i := <-data:
@@ -328,7 +329,7 @@ func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				log.Printf("error received: %s", e)
+				slog.Error(fmt.Sprintf("error received: %s", e))
 				c.FailNow()
 			}
 		}
@@ -346,7 +347,7 @@ func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
 	}
 
 	// Block receiving any notifications until all have been sent
-	log.Printf("All messages have been sent")
+	slog.Info("All messages have been sent")
 	close(blocker)
 
 	// Wait for test to complete

--- a/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
+++ b/pkg/rsnotify/listeners/postgrespq/pqlistener_test.go
@@ -3,7 +3,6 @@ package postgrespq
 // Copyright (C) 2022 by RStudio, PBC.
 
 import (
-	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -137,7 +136,7 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -189,7 +188,7 @@ func (s *PqNotifySuite) TestNotificationsNormal(c *check.C) {
 				c.Assert(i.(*testNotification).Val, check.Equals, "second-test")
 				return
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}
@@ -329,7 +328,7 @@ func (s *PqNotifySuite) TestNotificationsBlock(c *check.C) {
 					return
 				}
 			case e := <-errs:
-				slog.Error(fmt.Sprintf("error received: %s", e))
+				slog.Error("error received", "error", e)
 				c.FailNow()
 			}
 		}

--- a/pkg/rsqueue/runnerfactory/runnerfactory.go
+++ b/pkg/rsqueue/runnerfactory/runnerfactory.go
@@ -5,7 +5,7 @@ package runnerfactory
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -63,7 +63,7 @@ func (r *RunnerFactory) Stop(timeout time.Duration) error {
 			defer wg.Done()
 			err := runner.Stop(timeout)
 			if err != nil {
-				log.Printf("Error stopping runner for type %d: %s", key, err)
+				slog.Error(fmt.Sprintf("Error stopping runner for type %d: %s", key, err))
 			}
 			r.types.SetEnabled(key, false)
 		}(key, runner)

--- a/pkg/rsqueue/runnerfactory/runnerfactory.go
+++ b/pkg/rsqueue/runnerfactory/runnerfactory.go
@@ -63,7 +63,7 @@ func (r *RunnerFactory) Stop(timeout time.Duration) error {
 			defer wg.Done()
 			err := runner.Stop(timeout)
 			if err != nil {
-				slog.Error(fmt.Sprintf("Error stopping runner for type %d: %s", key, err))
+				slog.Error("Error stopping runner", "type", key, "error", err)
 			}
 			r.types.SetEnabled(key, false)
 		}(key, runner)

--- a/pkg/rsstorage/internal/chunks.go
+++ b/pkg/rsstorage/internal/chunks.go
@@ -108,7 +108,7 @@ func (w *DefaultChunkUtils) WriteChunked(
 				})
 				if err != nil {
 					// TODO: Update DefaultChunkUtils to acceptable a logger
-					slog.Error(fmt.Sprintf("Error notifying store of chunk completion for address=%s; chunk=%d: %s", address, count, err))
+					slog.Error("Error notifying store of chunk completion", "address", address, "chunk", count, "error", err)
 				}
 				if count == numChunks {
 					return nil

--- a/pkg/rsstorage/internal/chunks.go
+++ b/pkg/rsstorage/internal/chunks.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -108,7 +108,7 @@ func (w *DefaultChunkUtils) WriteChunked(
 				})
 				if err != nil {
 					// TODO: Update DefaultChunkUtils to acceptable a logger
-					log.Printf("Error notifying store of chunk completion for address=%s; chunk=%d: %s", address, count, err)
+					slog.Error(fmt.Sprintf("Error notifying store of chunk completion for address=%s; chunk=%d: %s", address, count, err))
 				}
 				if count == numChunks {
 					return nil

--- a/pkg/rsstorage/internal/integration_test/chunks_test.go
+++ b/pkg/rsstorage/internal/integration_test/chunks_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -141,9 +140,9 @@ func (s *ChunksIntegrationSuite) TestWriteChunked(c *check.C) {
 	serverSet := s.NewServerSet(c, "chunks", "")
 	for key, server := range serverSet {
 		if testing.Short() && key != "file" {
-			slog.Info(fmt.Sprintf("skipping chunks integration tests for %s because -short was provided", key))
+			slog.Info("skipping chunks integration tests because -short was provided", "server", key)
 		} else {
-			slog.Info(fmt.Sprintf("testing chunks integration tests for %s", key))
+			slog.Info("testing chunks integration tests", "server", key)
 			s.check(c, server)
 		}
 	}
@@ -249,7 +248,7 @@ func (s *ChunksPartialReadSuite) TearDownSuite(c *check.C) {
 
 func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	ctx := context.Background()
-	slog.Info(fmt.Sprintf("Starting test %s", c.TestName()))
+	slog.Info("Starting test", "name", c.TestName())
 	defer leaktest.Check(c)
 
 	sz := uint64(len(servertest.TestDESC))
@@ -314,7 +313,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	resolve := func(writer io.Writer) (dir, address string, err error) {
 		defer pR.Close()
 		n, err := io.Copy(writer, pR)
-		slog.Info(fmt.Sprintf("Done resolving %d bytes", n))
+		slog.Info("Done resolving", "bytes", n)
 		return
 	}
 
@@ -417,7 +416,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialTimeout(c *check.C) {
 	resolve := func(writer io.Writer) (dir, address string, err error) {
 		defer pR.Close()
 		n, err := io.Copy(writer, pR)
-		slog.Info(fmt.Sprintf("Done resolving %d bytes", n))
+		slog.Info("Done resolving", "bytes", n)
 		return
 	}
 

--- a/pkg/rsstorage/internal/integration_test/chunks_test.go
+++ b/pkg/rsstorage/internal/integration_test/chunks_test.go
@@ -8,8 +8,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
@@ -140,9 +141,9 @@ func (s *ChunksIntegrationSuite) TestWriteChunked(c *check.C) {
 	serverSet := s.NewServerSet(c, "chunks", "")
 	for key, server := range serverSet {
 		if testing.Short() && key != "file" {
-			log.Printf("skipping chunks integration tests for %s because -short was provided", key)
+			slog.Info(fmt.Sprintf("skipping chunks integration tests for %s because -short was provided", key))
 		} else {
-			log.Printf("testing chunks integration tests for %s", key)
+			slog.Info(fmt.Sprintf("testing chunks integration tests for %s", key))
 			s.check(c, server)
 		}
 	}
@@ -248,7 +249,7 @@ func (s *ChunksPartialReadSuite) TearDownSuite(c *check.C) {
 
 func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	ctx := context.Background()
-	log.Printf("Starting test %s", c.TestName())
+	slog.Info(fmt.Sprintf("Starting test %s", c.TestName()))
 	defer leaktest.Check(c)
 
 	sz := uint64(len(servertest.TestDESC))
@@ -313,7 +314,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	resolve := func(writer io.Writer) (dir, address string, err error) {
 		defer pR.Close()
 		n, err := io.Copy(writer, pR)
-		log.Printf("Done resolving %d bytes", n)
+		slog.Info(fmt.Sprintf("Done resolving %d bytes", n))
 		return
 	}
 
@@ -321,12 +322,12 @@ func (s *ChunksPartialReadSuite) TestReadPartialOk(c *check.C) {
 	go func() {
 		err = cw.WriteChunked(ctx, "0a", "test-chunk", sz, resolve)
 		c.Assert(err, check.IsNil)
-		log.Printf("Done with WriteChunked")
+		slog.Info("Done with WriteChunked")
 	}()
 
 	// Wait for 100 chunks to be written
 	<-readStart
-	log.Printf("Starting ReadChunked after writing 100 chunks")
+	slog.Info("Starting ReadChunked after writing 100 chunks")
 
 	// Read chunks and assemble them...
 	r, _, size, mod, err := cw.ReadChunked(ctx, "0a", "test-chunk")
@@ -406,7 +407,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialTimeout(c *check.C) {
 
 			// On chunk 105, hang
 			if index == 105 {
-				log.Printf("Hanging for 1 minute to simulate timeout")
+				slog.Info("Hanging for 1 minute to simulate timeout")
 				time.Sleep(time.Minute)
 			}
 		}
@@ -416,7 +417,7 @@ func (s *ChunksPartialReadSuite) TestReadPartialTimeout(c *check.C) {
 	resolve := func(writer io.Writer) (dir, address string, err error) {
 		defer pR.Close()
 		n, err := io.Copy(writer, pR)
-		log.Printf("Done resolving %d bytes", n)
+		slog.Info(fmt.Sprintf("Done resolving %d bytes", n))
 		return
 	}
 
@@ -424,12 +425,12 @@ func (s *ChunksPartialReadSuite) TestReadPartialTimeout(c *check.C) {
 	go func() {
 		err = cw.WriteChunked(ctx, "0a", "test-chunk", sz, resolve)
 		c.Assert(err, check.IsNil)
-		log.Printf("Done with WriteChunked")
+		slog.Info("Done with WriteChunked")
 	}()
 
 	// Wait for 100 chunks to be written
 	<-readStart
-	log.Printf("Starting ReadChunked after writing 100 chunks")
+	slog.Info("Starting ReadChunked after writing 100 chunks")
 
 	// Read chunks and assemble them...
 	r, _, size, mod, err := cw.ReadChunked(ctx, "0a", "test-chunk")

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -268,7 +268,7 @@ func (s *StorageIntegrationSuite) CheckFile(
 	sz int64,
 	chunked bool,
 ) {
-	slog.Info(fmt.Sprintf("(%s) Verifying existence of %s on server=%s (with dir=%s)", test, address, class, dir))
+	slog.Info("Verifying existence", "test", test, "address", address, "server", class, "dir", dir)
 
 	// Next, get it
 	r, ch, sz, _, ok, err := server.Get(context.Background(), dir, address)
@@ -297,7 +297,7 @@ func (s *StorageIntegrationSuite) CheckFile(
 
 // Verifies that a given asset does not exist
 func (s *StorageIntegrationSuite) CheckFileGone(c *check.C, server rsstorage.StorageServer, test, dir, address, classSource string) {
-	slog.Info(fmt.Sprintf("(%s) Verifying removal of %s on server=%s (with dir=%s)", test, address, classSource, dir))
+	slog.Info("Verifying removal", "test", test, "address", address, "server", classSource, "dir", dir)
 
 	ok, _, _, _, err := server.Check(context.Background(), "", address)
 	c.Check(err, check.IsNil)
@@ -326,7 +326,7 @@ func (s *StorageIntegrationSuite) TestMoving(c *check.C) {
 
 	// Verify
 	for classSource := range sources {
-		slog.Info(fmt.Sprintf("\nVerify that files were successfully moved from %s to each destination server:", classSource))
+		slog.Info("Verify that files were successfully moved to each destination server", "source", classSource)
 		for classDest, dest := range dests {
 			// Files exist on destination
 			s.CheckFile(
@@ -367,7 +367,7 @@ func (s *StorageIntegrationSuite) TestMoving(c *check.C) {
 
 	// Verify that files do not exist on source
 	for classSource, source := range sources {
-		slog.Info(fmt.Sprintf("\nVerify that moved files were deleted from the %s server:", classSource))
+		slog.Info("Verify that moved files were deleted from the server", "source", classSource)
 		for classDest := range dests {
 			s.CheckFileGone(c, source, "MoveSrc", "", fmt.Sprintf("%s--%s", classSource, classDest), classSource)
 			s.CheckFileGone(c, source, "MoveSrc", "dir", fmt.Sprintf("%s--%s", classSource, classDest), classSource)
@@ -397,7 +397,7 @@ func (s *StorageIntegrationSuite) TestCopying(c *check.C) {
 
 	// Verify files have been copied to destination
 	for classSource := range sources {
-		slog.Info(fmt.Sprintf("\nVerify that files were successfully copied from %s to each destination server:", classSource))
+		slog.Info("Verify that files were successfully copied to each destination server", "source", classSource)
 		for classDest, dest := range dests {
 			// Files exist on destination
 			s.CheckFile(
@@ -438,7 +438,7 @@ func (s *StorageIntegrationSuite) TestCopying(c *check.C) {
 
 	// Verify files are still on source
 	for classSource, source := range sources {
-		slog.Info(fmt.Sprintf("\nVerify that original files still remain on the %s server:", classSource))
+		slog.Info("Verify that original files still remain on the server", "source", classSource)
 		for classDest := range dests {
 			// Files still exist on source
 			s.CheckFile(
@@ -479,14 +479,14 @@ func (s *StorageIntegrationSuite) TestCopying(c *check.C) {
 
 	// Test Enumeration
 	for classSource, source := range sources {
-		slog.Info(fmt.Sprintf("\nVerify enumeration on the %s source server:", classSource))
+		slog.Info("Verify enumeration on the source server", "source", classSource)
 		items, err := source.Enumerate(ctx)
 		c.Assert(err, check.IsNil)
 		// Each source should have three files for each destination
 		c.Assert(items, check.HasLen, len(dests)*3)
 	}
 	for classDest, dest := range dests {
-		slog.Info(fmt.Sprintf("\nVerify enumeration on the %s destination server:", classDest))
+		slog.Info("Verify enumeration on the destination server", "dest", classDest)
 		items, err := dest.Enumerate(ctx)
 		c.Assert(err, check.IsNil)
 		// Each destination should have three files from each source
@@ -495,7 +495,7 @@ func (s *StorageIntegrationSuite) TestCopying(c *check.C) {
 
 	// Test Removal
 	for classSource, source := range sources {
-		slog.Info(fmt.Sprintf("\nVerify forced removal of assets on the %s source server:", classSource))
+		slog.Info("Verify forced removal of assets on the source server", "source", classSource)
 		for classDest := range dests {
 			err := source.Remove(ctx, "", fmt.Sprintf("%s--%s", classSource, classDest))
 			c.Assert(err, check.IsNil)

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -136,7 +136,7 @@ func (s *StorageServer) CalculateUsage() (types.Usage, error) {
 
 	timeInfo := time.Now()
 	elapsed := timeInfo.Sub(start)
-	slog.Debug(fmt.Sprintf("Calculated disk info for %s in %s.\n", s.dir, elapsed))
+	slog.Debug("Calculated disk info", "dir", s.dir, "elapsed", elapsed)
 
 	actual, err := diskUsage(s.dir, s.cacheTimeout, s.walkTimeout)
 	if err != nil {
@@ -145,7 +145,7 @@ func (s *StorageServer) CalculateUsage() (types.Usage, error) {
 
 	timeUsage := time.Now()
 	elapsed = timeUsage.Sub(timeInfo)
-	slog.Debug(fmt.Sprintf("Calculated disk usage for %s in %s.\n", s.dir, elapsed))
+	slog.Debug("Calculated disk usage", "dir", s.dir, "elapsed", elapsed)
 
 	usage := types.Usage{
 		SizeBytes:       datasize.ByteSize(all),
@@ -320,7 +320,7 @@ func (s *StorageServer) write(resolve types.Resolver) (dir, address, staging str
 	defer stagingFile.Close()
 	staging = stagingFile.Name()
 
-	slog.Debug(fmt.Sprintf("Opened new staging file for storage: %s.\n", stagingFile.Name()))
+	slog.Debug("Opened new staging file for storage", "file", stagingFile.Name())
 
 	// Resolve/get the data we need
 	dir, address, err = resolve(stagingFile)
@@ -336,7 +336,7 @@ func (s *StorageServer) cleanup(staging string) {
 	removeError := s.fileIO.Remove(staging)
 	if removeError != nil && !os.IsNotExist(removeError) {
 		// Warn and discard errors cleaning up
-		slog.Debug(fmt.Sprintf("file.StorageServer error while cleaning up staged data: %s", removeError))
+		slog.Debug("file.StorageServer error while cleaning up staged data", "error", removeError)
 	}
 }
 
@@ -361,7 +361,7 @@ func (s *StorageServer) Remove(ctx context.Context, dir, address string) error {
 func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
 	items, err := enumerate(s.dir, s.walkTimeout)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Error enumerating storage: %s", err))
+		slog.Error("Error enumerating storage", "error", err)
 
 		return nil, err
 	}
@@ -383,7 +383,7 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 
 		err := filepath.WalkDir(dir, func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
-				slog.Error(fmt.Sprintf("Error enumerating storage for directory %s: %s", dir, err))
+				slog.Error("Error enumerating storage for directory", "dir", dir, "error", err)
 				return nil
 			}
 
@@ -445,10 +445,10 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 func (s *StorageServer) move(dir, address string, server rsstorage.StorageServer) error {
 	source := s.Locate(dir, address)
 	dest := server.Locate(dir, address)
-	slog.Debug(fmt.Sprintf("Renaming %s to %s", source, dest))
+	slog.Debug("Renaming file", "source", source, "dest", dest)
 	destDir := filepath.Dir(dest)
 	if destDir != dest {
-		slog.Debug(fmt.Sprintf("Ensuring directory %s exists", destDir))
+		slog.Debug("Ensuring directory exists", "dir", destDir)
 		err := os.MkdirAll(destDir, 0700)
 		if err != nil {
 			return err
@@ -456,7 +456,7 @@ func (s *StorageServer) move(dir, address string, server rsstorage.StorageServer
 	}
 	err := os.Rename(source, dest)
 	if err != nil {
-		slog.Debug(fmt.Sprintf("Error moving with os.Rename: %s", err))
+		slog.Debug("Error moving with os.Rename", "error", err)
 		return err
 	}
 

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -362,7 +361,7 @@ func (s *StorageServer) Remove(ctx context.Context, dir, address string) error {
 func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
 	items, err := enumerate(s.dir, s.walkTimeout)
 	if err != nil {
-		log.Printf("Error enumerating storage: %s", err)
+		slog.Error(fmt.Sprintf("Error enumerating storage: %s", err))
 
 		return nil, err
 	}
@@ -384,7 +383,7 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 
 		err := filepath.WalkDir(dir, func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
-				log.Printf("Error enumerating storage for directory %s: %s", dir, err)
+				slog.Error(fmt.Sprintf("Error enumerating storage for directory %s: %s", dir, err))
 				return nil
 			}
 

--- a/pkg/rsstorage/servers/s3server/s3_enumeration.go
+++ b/pkg/rsstorage/servers/s3server/s3_enumeration.go
@@ -136,7 +136,7 @@ func (a *DefaultAwsOps) BucketObjects(
 					atomic.AddUint64(&ops, uint64(len(bm)))
 					if ops > 1000 {
 						atomic.AddUint64(&total, atomic.LoadUint64(&ops))
-						slog.Info(fmt.Sprintf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total)))
+						slog.Info("Parsed S3 files", "prefix", s3Prefix, "fileCount", atomic.LoadUint64(&total))
 						atomic.SwapUint64(&ops, 0)
 					}
 
@@ -249,7 +249,7 @@ func (a *DefaultAwsOps) BucketObjectsETagMap(
 					atomic.AddUint64(&ops, uint64(len(bm)))
 					if ops > 1000 {
 						atomic.AddUint64(&total, atomic.LoadUint64(&ops))
-						slog.Info(fmt.Sprintf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total)))
+						slog.Info("Parsed S3 files", "prefix", s3Prefix, "fileCount", atomic.LoadUint64(&total))
 						atomic.SwapUint64(&ops, 0)
 					}
 

--- a/pkg/rsstorage/servers/s3server/s3_enumeration.go
+++ b/pkg/rsstorage/servers/s3server/s3_enumeration.go
@@ -5,7 +5,7 @@ package s3server
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 	"strings"
 	"sync"
@@ -136,7 +136,7 @@ func (a *DefaultAwsOps) BucketObjects(
 					atomic.AddUint64(&ops, uint64(len(bm)))
 					if ops > 1000 {
 						atomic.AddUint64(&total, atomic.LoadUint64(&ops))
-						log.Printf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total))
+						slog.Info(fmt.Sprintf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total)))
 						atomic.SwapUint64(&ops, 0)
 					}
 
@@ -249,7 +249,7 @@ func (a *DefaultAwsOps) BucketObjectsETagMap(
 					atomic.AddUint64(&ops, uint64(len(bm)))
 					if ops > 1000 {
 						atomic.AddUint64(&total, atomic.LoadUint64(&ops))
-						log.Printf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total))
+						slog.Info(fmt.Sprintf("For S3 prefix %s parsed %d files", s3Prefix, atomic.LoadUint64(&total)))
 						atomic.SwapUint64(&ops, 0)
 					}
 


### PR DESCRIPTION
platform-lib is currently partially migrated to slog, with a lot of `log.Printf()`'s remaining.

This finishes up the migration for all packages within it, because error logs getting logged to `INFO` has been causing problems:
```sh
INFO Received error on queue addressed work notification channel: ... connection timed out

INFO Error pushing leader assumption work to queue: Duplicate address 

INFO Error verifying cluster integrity: node list length differs. Store node count 2 does not match leader count 1
```

**Note:** this is just a simple find-and-replace style swap of `log.Printf()` to `slog.Info(fmt.Sprintf(...))`. It's not idiomatic slog using key-val pairs but I wanted to keep this as simple to review as possible. Most of the other slog uses in platform-lib use key-val pairs either. I think we just migrate those either all at once or when updating individual files in the future.