### PR TITLE
fix: fail fast when task is registered after Handle()

### DIFF
--- a/pkg/rselection/taskhandler.go
+++ b/pkg/rselection/taskhandler.go
@@ -67,6 +67,9 @@ func NewGenericTaskHandler(cfg GenericTaskHandlerConfig) *GenericTaskHandler {
 	}
 }
 
+// Register adds a task to the handler. It must be called before Handle().
+// Calling Register after Handle() or registering the same task name twice
+// will cause the program to exit via log.Fatalf.
 func (h *GenericTaskHandler) Register(name string, task Task) {
 	if h.cancel != nil {
 		logFatalf("Task %q registered after Handle() was called; it will never run", name)

--- a/pkg/rselection/taskhandler.go
+++ b/pkg/rselection/taskhandler.go
@@ -13,6 +13,9 @@ import (
 	"github.com/rstudio/platform-lib/v2/pkg/rsnotify/broadcaster"
 )
 
+// logFatalf is used for fatal errors and can be overridden in tests.
+var logFatalf = log.Fatalf
+
 const (
 	TaskTypePersistent uint8 = 0
 	TaskTypeScheduled  uint8 = 1
@@ -65,8 +68,11 @@ func NewGenericTaskHandler(cfg GenericTaskHandlerConfig) *GenericTaskHandler {
 }
 
 func (h *GenericTaskHandler) Register(name string, task Task) {
+	if h.cancel != nil {
+		logFatalf("Task %q registered after Handle() was called; it will never run", name)
+	}
 	if _, ok := h.tasks[name]; ok {
-		log.Fatalf("Attempted to register a task %s that is already registered", name)
+		logFatalf("Attempted to register a task %s that is already registered", name)
 	}
 	h.tasks[name] = task
 }

--- a/pkg/rselection/taskhandler_test.go
+++ b/pkg/rselection/taskhandler_test.go
@@ -4,6 +4,7 @@ package rselection
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fortytw2/leaktest"
@@ -48,6 +49,37 @@ func (t *TestTaskPersistent) Run(ctx context.Context, b broadcaster.Broadcaster)
 		t.ok <- true
 	case <-ctx.Done():
 	}
+}
+
+func (s *TaskHandlerSuite) TestRegisterAfterHandleFatals(c *check.C) {
+	defer leaktest.Check(c)
+
+	handler := NewGenericTaskHandler(GenericTaskHandlerConfig{})
+	handler.Handle(nil)
+
+	// Registering a task after Handle() should fatal.
+	// Capture log.Fatalf by replacing it temporarily.
+	var fatalMsg string
+	origFatalf := logFatalf
+	logFatalf = func(format string, v ...interface{}) {
+		fatalMsg = fmt.Sprintf(format, v...)
+	}
+	defer func() { logFatalf = origFatalf }()
+
+	handler.Register("late-task", &TestTask{
+		GenericTask: GenericTask{
+			TaskName: "late-task",
+			TaskType: TaskTypeScheduled,
+			TaskSchedule: &IntervalSchedule{
+				Ticker: make(chan time.Time),
+			},
+		},
+		ran: new(int),
+		n:   make(chan bool),
+	})
+
+	c.Assert(fatalMsg, check.Matches, `.*registered after Handle\(\).*`)
+	handler.Stop()
 }
 
 func (s *TaskHandlerSuite) TestGenericTaskHandler(c *check.C) {


### PR DESCRIPTION
## Summary

- Add a runtime guard in `GenericTaskHandler.Register()` that fatals if a task is registered after `Handle()` has already been called
- `Handle()` iterates the task map once to start goroutines — any task registered afterward exists in the map but never gets a goroutine, silently failing
- This was the root cause of rstudio/package-manager#17126, where the OpenVSX auto-sync task was registered ~270 lines after `Handle()` had run

## Changes

- `Register()` now checks if `h.cancel != nil` (set by `Handle()`) and fatals with a clear message if so
- Existing `log.Fatalf` calls use a package-level `logFatalf` variable to allow test overrides
- Added `TestRegisterAfterHandleFatals` test

## Test plan

- [x] Existing `TestGenericTaskHandler` passes (registration before `Handle()` still works)
- [x] New `TestRegisterAfterHandleFatals` verifies the guard triggers

Related: rstudio/package-manager#17328

🤖 Generated with [Claude Code](https://claude.com/claude-code)