### PR TITLE
Update S3 based storage to accept AWS S3 client interface for instantiation

### DIFF
--- a/pkg/rsstorage/internal/integration_test/chunks_test.go
+++ b/pkg/rsstorage/internal/integration_test/chunks_test.go
@@ -59,7 +59,7 @@ func (s *ChunksIntegrationSuite) TearDownTest(c *check.C) {
 func (s *ChunksIntegrationSuite) NewServerSet(c *check.C, class, prefix string) map[string]rsstorage.StorageServer {
 	baseEndpoint := "http://minio:9000"
 	ctx := context.Background()
-	s3Svc := s3server.NewS3Wrapper(s3.New(
+	s3Svc, err := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:          "us-east-1",
 			BaseEndpoint:    &baseEndpoint,
@@ -68,6 +68,8 @@ func (s *ChunksIntegrationSuite) NewServerSet(c *check.C, class, prefix string) 
 			Credentials:     credentials.NewStaticCredentialsProvider("minio", "miniokey", ""),
 		},
 	))
+	c.Assert(err, check.IsNil)
+	c.Assert(s3Svc, check.NotNil)
 
 	// Create S3 bucket
 	if !testing.Short() {

--- a/pkg/rsstorage/internal/integration_test/chunks_test.go
+++ b/pkg/rsstorage/internal/integration_test/chunks_test.go
@@ -59,7 +59,7 @@ func (s *ChunksIntegrationSuite) TearDownTest(c *check.C) {
 func (s *ChunksIntegrationSuite) NewServerSet(c *check.C, class, prefix string) map[string]rsstorage.StorageServer {
 	baseEndpoint := "http://minio:9000"
 	ctx := context.Background()
-	s3Svc, err := s3server.NewS3Wrapper(
+	s3Svc := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:          "us-east-1",
 			BaseEndpoint:    &baseEndpoint,
@@ -67,12 +67,11 @@ func (s *ChunksIntegrationSuite) NewServerSet(c *check.C, class, prefix string) 
 			EndpointOptions: s3.EndpointResolverOptions{DisableHTTPS: true},
 			Credentials:     credentials.NewStaticCredentialsProvider("minio", "miniokey", ""),
 		},
-	)
-	c.Assert(err, check.IsNil)
+	))
 
 	// Create S3 bucket
 	if !testing.Short() {
-		_, err = s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{
+		_, err := s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{
 			Bucket: aws.String(class),
 		})
 		c.Assert(err, check.IsNil)

--- a/pkg/rsstorage/internal/integration_test/integration.go
+++ b/pkg/rsstorage/internal/integration_test/integration.go
@@ -74,10 +74,7 @@ func getStorageServerAttempt(
 			s3Opts.EndpointOptions = s3.EndpointResolverOptions{DisableHTTPS: cfg.S3.DisableSSL}
 		}
 
-		s3Service, err := s3server.NewS3Wrapper(s3Opts)
-		if err != nil {
-			return nil, fmt.Errorf("Error starting S3 session for '%s': %s", class, err)
-		}
+		s3Service := s3server.NewS3Wrapper(s3.New(s3Opts))
 
 		server = s3server.NewStorageServer(s3server.StorageServerArgs{
 			Bucket:    cfg.S3.Bucket,
@@ -93,7 +90,7 @@ func getStorageServerAttempt(
 		}
 
 		s3, _ := server.(*s3server.StorageServer)
-		err = s3.Validate(ctx)
+		err := s3.Validate(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("Error validating S3 session for '%s': %s", class, err)
 		}

--- a/pkg/rsstorage/internal/integration_test/integration.go
+++ b/pkg/rsstorage/internal/integration_test/integration.go
@@ -74,7 +74,10 @@ func getStorageServerAttempt(
 			s3Opts.EndpointOptions = s3.EndpointResolverOptions{DisableHTTPS: cfg.S3.DisableSSL}
 		}
 
-		s3Service := s3server.NewS3Wrapper(s3.New(s3Opts))
+		s3Service, err := s3server.NewS3Wrapper(s3.New(s3Opts))
+		if err != nil {
+			return nil, fmt.Errorf("unable to create S3 wrapper: %w", err)
+		}
 
 		server = s3server.NewStorageServer(s3server.StorageServerArgs{
 			Bucket:    cfg.S3.Bucket,
@@ -90,7 +93,7 @@ func getStorageServerAttempt(
 		}
 
 		s3, _ := server.(*s3server.StorageServer)
-		err := s3.Validate(ctx)
+		err = s3.Validate(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("Error validating S3 session for '%s': %s", class, err)
 		}

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -147,7 +147,7 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 
 	endpointURL, _ := url.Parse("http://minio:9000")
 
-	s3Svc := s3server.NewS3Wrapper(s3.New(
+	s3Svc, err := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:             "us-east-1",
 			EndpointOptions:    s3.EndpointResolverOptions{DisableHTTPS: true},
@@ -160,9 +160,10 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 			//Logger: logging.NewStandardLogger(os.Stdout),
 		},
 	))
+	c.Assert(err, check.IsNil)
 
 	// Create S3 bucket
-	_, err := s3Svc.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(class)})
+	_, err = s3Svc.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(class)})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(s.pool, check.NotNil)
@@ -559,7 +560,7 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHang(c *check.C) {
 		forcePathStyle = true
 	}
 
-	s3Svc := s3server.NewS3Wrapper(s3.New(
+	s3Svc, err := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:          region,
 			BaseEndpoint:    &endpoint,
@@ -572,9 +573,10 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHang(c *check.C) {
 			//Logger:          logging.NewStandardLogger(os.Stdout),
 		},
 	))
+	c.Assert(err, check.IsNil)
+	c.Assert(s3Svc, check.NotNil)
 
 	// Create S3 bucket if using local MinIO Server
-	var err error
 	if endpoint == minioEndpoint {
 		_, err = s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		// Ignore errors if the bucket already exists.
@@ -697,7 +699,7 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHangChunked(c *check.C) {
 
 	// commenting out the credentials for now so the test fails quickly
 	// instead of hanging up
-	s3Svc := s3server.NewS3Wrapper(s3.New(
+	s3Svc, err := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:             region,
 			BaseEndpoint:       &endpoint,
@@ -711,9 +713,10 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHangChunked(c *check.C) {
 			//Logger:             logging.NewStandardLogger(os.Stdout),
 		},
 	))
+	c.Assert(err, check.IsNil)
+	c.Assert(s3Svc, check.NotNil)
 
 	// Create S3 bucket if using local MinIO Server
-	var err error
 	if endpoint == minioEndpoint {
 		_, err = s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		// Ignore errors if the bucket already exists.

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -147,7 +147,7 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 
 	endpointURL, _ := url.Parse("http://minio:9000")
 
-	s3Svc, err := s3server.NewS3Wrapper(
+	s3Svc := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:             "us-east-1",
 			EndpointOptions:    s3.EndpointResolverOptions{DisableHTTPS: true},
@@ -159,11 +159,10 @@ func (s *StorageIntegrationSuite) NewServerSet(c *check.C, class, prefix string)
 			//ClientLogMode:      aws.LogRequestWithBody | aws.LogResponseWithBody,
 			//Logger: logging.NewStandardLogger(os.Stdout),
 		},
-	)
-	c.Assert(err, check.IsNil)
+	))
 
 	// Create S3 bucket
-	_, err = s3Svc.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(class)})
+	_, err := s3Svc.CreateBucket(context.Background(), &s3.CreateBucketInput{Bucket: aws.String(class)})
 	c.Assert(err, check.IsNil)
 
 	c.Assert(s.pool, check.NotNil)
@@ -560,7 +559,7 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHang(c *check.C) {
 		forcePathStyle = true
 	}
 
-	s3Svc, err := s3server.NewS3Wrapper(
+	s3Svc := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:          region,
 			BaseEndpoint:    &endpoint,
@@ -572,10 +571,10 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHang(c *check.C) {
 			//ClientLogMode:   aws.LogRequestWithBody | aws.LogResponseWithBody,
 			//Logger:          logging.NewStandardLogger(os.Stdout),
 		},
-	)
-	c.Assert(err, check.IsNil)
+	))
 
 	// Create S3 bucket if using local MinIO Server
+	var err error
 	if endpoint == minioEndpoint {
 		_, err = s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		// Ignore errors if the bucket already exists.
@@ -698,7 +697,7 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHangChunked(c *check.C) {
 
 	// commenting out the credentials for now so the test fails quickly
 	// instead of hanging up
-	s3Svc, err := s3server.NewS3Wrapper(
+	s3Svc := s3server.NewS3Wrapper(s3.New(
 		s3.Options{
 			Region:             region,
 			BaseEndpoint:       &endpoint,
@@ -711,10 +710,10 @@ func (s *S3IntegrationSuite) TestPopulateServerSetHangChunked(c *check.C) {
 			//ClientLogMode:      aws.LogRequestWithBody | aws.LogResponseWithBody,
 			//Logger:             logging.NewStandardLogger(os.Stdout),
 		},
-	)
-	c.Assert(err, check.IsNil)
+	))
 
 	// Create S3 bucket if using local MinIO Server
+	var err error
 	if endpoint == minioEndpoint {
 		_, err = s3Svc.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(bucket)})
 		// Ignore errors if the bucket already exists.

--- a/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
@@ -6,63 +6,47 @@ import (
 	"context"
 	"fmt"
 
-	encryptClient "github.com/aws/amazon-s3-encryption-client-go/v3/client"
-	"github.com/aws/amazon-s3-encryption-client-go/v3/materials"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/rstudio/platform-lib/v3/pkg/rsstorage/internal"
 )
 
-type encryptedS3Service struct {
-	client *encryptClient.S3EncryptionClientV3
+type EncryptedS3Service struct {
+	client S3API
 }
 
-func NewEncryptedS3Wrapper(s3Opts s3.Options, kmsOpts kms.Options, keyID string) (S3Wrapper, error) {
-	if s3Opts.Region == "" || kmsOpts.Region == "" {
-		return nil, fmt.Errorf("AWS configuration option 'region' is required")
+// NewEncryptedS3Wrapper constructs a S3Wrapper backed by a client-side
+// encryption-aware S3 client (typically *encryptClient.S3EncryptionClientV3).
+// Callers are responsible for constructing the encryption client themselves
+// — including the underlying *s3.Client, *kms.Client, and
+// CryptographicMaterialsManager — and passing it in here.
+func NewEncryptedS3Wrapper(client S3API) (*EncryptedS3Service, error) {
+	if client == nil {
+		return nil, fmt.Errorf("an S3 client must be provided to NewEncryptedS3Wrapper")
 	}
-
-	s3Client := s3.New(s3Opts)
-	kmsClient := kms.New(kmsOpts)
-
-	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsClient, keyID))
-	if err != nil {
-		return nil, fmt.Errorf("error encounted while initializing crytographic manager: %w", err)
-	}
-	client, err := encryptClient.New(s3Client, cmm)
-	if err != nil {
-		return nil, fmt.Errorf("unable to initialize S3 encryption client: %w", err)
-	}
-
-	return &encryptedS3Service{
+	return &EncryptedS3Service{
 		client: client,
 	}, nil
 }
 
-func (s *encryptedS3Service) getConfig() config.Config {
-	return s.client.Options
-}
-
-func (s *encryptedS3Service) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+func (s *EncryptedS3Service) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	return s.client.CreateBucket(ctx, input)
 }
 
-func (s *encryptedS3Service) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+func (s *EncryptedS3Service) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
 	return s.client.DeleteBucket(ctx, input)
 }
 
-func (s *encryptedS3Service) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+func (s *EncryptedS3Service) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 	return s.client.HeadObject(ctx, input)
 }
 
-func (s *encryptedS3Service) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+func (s *EncryptedS3Service) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	return s.client.DeleteObject(ctx, input)
 }
 
-func (s *encryptedS3Service) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *EncryptedS3Service) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.HeadObject(ctx, &s3.HeadObjectInput{Key: &oldKey, Bucket: &oldBucket})
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -88,7 +72,7 @@ func (s *encryptedS3Service) CopyObject(ctx context.Context, oldBucket, oldKey, 
 	return out, nil
 }
 
-func (s *encryptedS3Service) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *EncryptedS3Service) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Key:    &oldKey,
 		Bucket: &oldBucket,
@@ -114,21 +98,21 @@ func (s *encryptedS3Service) MoveObject(ctx context.Context, oldBucket, oldKey, 
 	return out, nil
 }
 
-func (s *encryptedS3Service) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+func (s *EncryptedS3Service) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
 	return s.client.ListObjectsV2(ctx, input)
 }
 
 // Upload takes the same input as the defaultS3Service *s3.UploadInput,
-func (s *encryptedS3Service) Upload(ctx context.Context, input *s3.PutObjectInput, options ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
+func (s *EncryptedS3Service) Upload(ctx context.Context, input *s3.PutObjectInput, options ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
 	uploader := manager.NewUploader(s.client)
 	return uploader.Upload(ctx, input, options...)
 }
 
 // GetObject downloads an encrypted file from S3 and returns the plaintext value using client-side KMS decryption
-func (s *encryptedS3Service) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+func (s *EncryptedS3Service) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	return s.client.GetObject(ctx, input)
 }
 
-func (s *encryptedS3Service) KmsEncrypted() bool {
+func (s *EncryptedS3Service) KmsEncrypted() bool {
 	return true
 }

--- a/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_encrypted_service.go
@@ -4,6 +4,7 @@ package s3server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -12,7 +13,7 @@ import (
 	"github.com/rstudio/platform-lib/v3/pkg/rsstorage/internal"
 )
 
-type EncryptedS3Service struct {
+type EncryptedS3Wrapper struct {
 	client S3API
 }
 
@@ -21,32 +22,32 @@ type EncryptedS3Service struct {
 // Callers are responsible for constructing the encryption client themselves
 // — including the underlying *s3.Client, *kms.Client, and
 // CryptographicMaterialsManager — and passing it in here.
-func NewEncryptedS3Wrapper(client S3API) (*EncryptedS3Service, error) {
+func NewEncryptedS3Wrapper(client S3API) (*EncryptedS3Wrapper, error) {
 	if client == nil {
-		return nil, fmt.Errorf("an S3 client must be provided to NewEncryptedS3Wrapper")
+		return nil, errors.New("unable to create S3 encrypted wrapper, S3 client is nil")
 	}
-	return &EncryptedS3Service{
+	return &EncryptedS3Wrapper{
 		client: client,
 	}, nil
 }
 
-func (s *EncryptedS3Service) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+func (s *EncryptedS3Wrapper) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	return s.client.CreateBucket(ctx, input)
 }
 
-func (s *EncryptedS3Service) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+func (s *EncryptedS3Wrapper) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
 	return s.client.DeleteBucket(ctx, input)
 }
 
-func (s *EncryptedS3Service) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+func (s *EncryptedS3Wrapper) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 	return s.client.HeadObject(ctx, input)
 }
 
-func (s *EncryptedS3Service) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+func (s *EncryptedS3Wrapper) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	return s.client.DeleteObject(ctx, input)
 }
 
-func (s *EncryptedS3Service) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *EncryptedS3Wrapper) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.HeadObject(ctx, &s3.HeadObjectInput{Key: &oldKey, Bucket: &oldBucket})
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -72,7 +73,7 @@ func (s *EncryptedS3Service) CopyObject(ctx context.Context, oldBucket, oldKey, 
 	return out, nil
 }
 
-func (s *EncryptedS3Service) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *EncryptedS3Wrapper) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Key:    &oldKey,
 		Bucket: &oldBucket,
@@ -98,21 +99,39 @@ func (s *EncryptedS3Service) MoveObject(ctx context.Context, oldBucket, oldKey, 
 	return out, nil
 }
 
-func (s *EncryptedS3Service) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
-	return s.client.ListObjectsV2(ctx, input)
+func (s *EncryptedS3Wrapper) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	// In AWS SDK v2, we need to handle pagination manually
+	// Create a paginator to iterate through all pages. S3API satisfies the
+	// s3.ListObjectsV2APIClient interface implicitly because it declares
+	// the same ListObjectsV2 method.
+	paginator := s3.NewListObjectsV2Paginator(s.client, input)
+
+	var allObjects []types.Object
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error encountered while listing objects: %w", err)
+		}
+		allObjects = append(allObjects, page.Contents...)
+	}
+
+	return &s3.ListObjectsV2Output{
+		Contents:    allObjects,
+		IsTruncated: new(false),
+	}, nil
 }
 
 // Upload takes the same input as the defaultS3Service *s3.UploadInput,
-func (s *EncryptedS3Service) Upload(ctx context.Context, input *s3.PutObjectInput, options ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
+func (s *EncryptedS3Wrapper) Upload(ctx context.Context, input *s3.PutObjectInput, options ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
 	uploader := manager.NewUploader(s.client)
 	return uploader.Upload(ctx, input, options...)
 }
 
 // GetObject downloads an encrypted file from S3 and returns the plaintext value using client-side KMS decryption
-func (s *EncryptedS3Service) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+func (s *EncryptedS3Wrapper) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	return s.client.GetObject(ctx, input)
 }
 
-func (s *EncryptedS3Service) KmsEncrypted() bool {
+func (s *EncryptedS3Wrapper) KmsEncrypted() bool {
 	return true
 }

--- a/pkg/rsstorage/servers/s3server/s3_encrypted_service_test.go
+++ b/pkg/rsstorage/servers/s3server/s3_encrypted_service_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	encryptClient "github.com/aws/amazon-s3-encryption-client-go/v3/client"
+	"github.com/aws/amazon-s3-encryption-client-go/v3/materials"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -23,24 +25,36 @@ var _ = check.Suite(&S3EncryptedServiceSuite{})
 const (
 	// Raw AWS responses generated via aws.LogDebugWithHTTPBody using test objects
 	kmsResponse = `{"CiphertextBlob":"AQIDAHjn6Sd1ah3Pq5ObkS0zZNMKPN158UNlAjJfcYmp3qOIJAGWPnUuTqUcLSVl0Sxk2OcOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQME/hVJ7LNrJ0uLrKcAgEQgDs8iwgfz3Ml4D8zMjCXjkb7GRysOsam4yAM/EE5Ynl+fgrzwGu6CYXjT1IstlAO4weQR6+yAlw3C5xhXw==","KeyId":"arn:aws:kms:us-east-1:528395739535:key/7ddec34f-7c3e-4875-a348-de761fc28b4f","Plaintext":"VZrCXyYuBdlGvFsiN7ZRvobqh5VyJmc16aaAJ2/6dEI="}`
+
+	testKeyID = "7ddec34f-7c3e-4875-a348-de761fc28b4f"
 )
+
+// newTestEncryptedClient builds an *encryptClient.S3EncryptionClientV3 wired
+// through the supplied http.Client for both S3 and KMS so tests can stub
+// responses with httpmock. This mirrors the construction work that callers
+// now perform themselves before handing the client to NewEncryptedS3Wrapper.
+func newTestEncryptedClient(c *check.C, httpClient *http.Client) *encryptClient.S3EncryptionClientV3 {
+	s3Client := s3.New(s3.Options{
+		Region:      "us-east-1",
+		Credentials: aws.AnonymousCredentials{},
+		HTTPClient:  httpClient,
+	})
+	kmsClient := kms.New(kms.Options{
+		Region:      "us-east-1",
+		Credentials: aws.AnonymousCredentials{},
+		HTTPClient:  httpClient,
+	})
+	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsClient, testKeyID))
+	c.Assert(err, check.IsNil)
+	client, err := encryptClient.New(s3Client, cmm)
+	c.Assert(err, check.IsNil)
+	return client
+}
 
 func (s *S3EncryptedServiceSuite) TestUpload(c *check.C) {
 	ctx := context.Background()
 	client := http.Client{}
-	s3Service, err := NewEncryptedS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-		kms.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-		"7ddec34f-7c3e-4875-a348-de761fc28b4f",
-	)
+	s3Service, err := NewEncryptedS3Wrapper(newTestEncryptedClient(c, &client))
 	c.Assert(err, check.IsNil)
 	httpmock.ActivateNonDefault(&client)
 	defer httpmock.DeactivateAndReset()
@@ -69,19 +83,7 @@ func (s *S3EncryptedServiceSuite) TestUpload(c *check.C) {
 
 func (s *S3EncryptedServiceSuite) TestGetObject(c *check.C) {
 	client := http.Client{}
-	s3Service, err := NewEncryptedS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-		kms.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-		"7ddec34f-7c3e-4875-a348-de761fc28b4f",
-	)
+	s3Service, err := NewEncryptedS3Wrapper(newTestEncryptedClient(c, &client))
 	c.Assert(err, check.IsNil)
 
 	httpmock.ActivateNonDefault(&client)

--- a/pkg/rsstorage/servers/s3server/s3_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_service.go
@@ -16,6 +16,33 @@ import (
 
 const S3Concurrency = 20
 
+// S3API is the subset of the AWS S3 client surface that the wrappers in this
+// package depend on. The concrete *s3.Client from the AWS SDK satisfies this
+// interface, as does *encryptClient.S3EncryptionClientV3 (via its embedded
+// *s3.Client). Callers construct the client of their choice and pass it to
+// NewS3Wrapper or NewEncryptedS3Wrapper. The interface also covers the
+// methods required by manager.NewUploader and s3.NewListObjectsV2Paginator
+// so that the wrapper implementations can use them without type assertions.
+type S3API interface {
+	// Bucket operations
+	CreateBucket(ctx context.Context, input *s3.CreateBucketInput, optFns ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
+	DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput, optFns ...func(*s3.Options)) (*s3.DeleteBucketOutput, error)
+
+	// Object operations
+	HeadObject(ctx context.Context, input *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	GetObject(ctx context.Context, input *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	CopyObject(ctx context.Context, input *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
+	ListObjectsV2(ctx context.Context, input *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+
+	// Multipart upload operations (required for manager.Uploader)
+	UploadPart(ctx context.Context, input *s3.UploadPartInput, optFns ...func(*s3.Options)) (*s3.UploadPartOutput, error)
+	CreateMultipartUpload(ctx context.Context, input *s3.CreateMultipartUploadInput, optFns ...func(*s3.Options)) (*s3.CreateMultipartUploadOutput, error)
+	CompleteMultipartUpload(ctx context.Context, input *s3.CompleteMultipartUploadInput, optFns ...func(*s3.Options)) (*s3.CompleteMultipartUploadOutput, error)
+	AbortMultipartUpload(ctx context.Context, input *s3.AbortMultipartUploadInput, optFns ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
+}
+
 // S3Wrapper encapsulates the S3 services we need
 type S3Wrapper interface {
 	CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
@@ -30,25 +57,27 @@ type S3Wrapper interface {
 	KmsEncrypted() bool
 }
 
-type defaultS3Wrapper struct {
-	client *s3.Client
+type DefaultS3Wrapper struct {
+	client S3API
 }
 
-func NewS3Wrapper(s3Opts s3.Options) (S3Wrapper, error) {
-	if s3Opts.Region == "" {
-		return nil, fmt.Errorf("'region' field of ConfigS3 is required")
+// NewS3Wrapper constructs a S3Wrapper backed by the provided S3 client. The
+// caller is responsible for configuring and constructing the client (e.g.
+// region, credentials, endpoint). Passing in the client rather than
+// configuration values lets callers wrap or replace the AWS SDK client with
+// their own implementation, which is useful for testing and for layering on
+// behaviors such as Object Lock-aware deletes.
+func NewS3Wrapper(client S3API) *DefaultS3Wrapper {
+	return &DefaultS3Wrapper{
+		client: client,
 	}
-
-	return &defaultS3Wrapper{
-		client: s3.New(s3Opts),
-	}, nil
 }
 
-func (s *defaultS3Wrapper) KmsEncrypted() bool {
+func (s *DefaultS3Wrapper) KmsEncrypted() bool {
 	return false
 }
 
-func (s *defaultS3Wrapper) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+func (s *DefaultS3Wrapper) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	out, err := s.client.CreateBucket(ctx, input)
 	if err != nil {
 		return nil, err
@@ -56,7 +85,7 @@ func (s *defaultS3Wrapper) CreateBucket(ctx context.Context, input *s3.CreateBuc
 	return out, err
 }
 
-func (s *defaultS3Wrapper) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+func (s *DefaultS3Wrapper) DeleteBucket(ctx context.Context, input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
 	out, err := s.client.DeleteBucket(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -67,7 +96,7 @@ func (s *defaultS3Wrapper) DeleteBucket(ctx context.Context, input *s3.DeleteBuc
 	return out, nil
 }
 
-func (s *defaultS3Wrapper) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+func (s *DefaultS3Wrapper) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 	out, err := s.client.HeadObject(ctx, input)
 	if err != nil {
 		var nskErr *types.NoSuchKey
@@ -83,7 +112,7 @@ func (s *defaultS3Wrapper) HeadObject(ctx context.Context, input *s3.HeadObjectI
 	return out, err
 }
 
-func (s *defaultS3Wrapper) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+func (s *DefaultS3Wrapper) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 	out, err := s.client.GetObject(ctx, input)
 	if err != nil {
 		var nskErr *types.NoSuchKey
@@ -99,7 +128,7 @@ func (s *defaultS3Wrapper) GetObject(ctx context.Context, input *s3.GetObjectInp
 	return out, err
 }
 
-func (s *defaultS3Wrapper) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+func (s *DefaultS3Wrapper) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
 	out, err := s.client.DeleteObject(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -110,7 +139,7 @@ func (s *defaultS3Wrapper) DeleteObject(ctx context.Context, input *s3.DeleteObj
 	return out, nil
 }
 
-func (s *defaultS3Wrapper) Upload(
+func (s *DefaultS3Wrapper) Upload(
 	ctx context.Context,
 	input *s3.PutObjectInput,
 	optFns ...func(uploader *manager.Uploader),
@@ -128,7 +157,7 @@ func (s *defaultS3Wrapper) Upload(
 	return out, err
 }
 
-func (s *defaultS3Wrapper) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *DefaultS3Wrapper) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.HeadObject(ctx, &s3.HeadObjectInput{Key: &oldKey, Bucket: &oldBucket})
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -154,7 +183,7 @@ func (s *defaultS3Wrapper) CopyObject(ctx context.Context, oldBucket, oldKey, ne
 	return out, nil
 }
 
-func (s *defaultS3Wrapper) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
+func (s *DefaultS3Wrapper) MoveObject(ctx context.Context, oldBucket, oldKey, newBucket, newKey string) (*s3.CopyObjectOutput, error) {
 	head, err := s.client.HeadObject(ctx, &s3.HeadObjectInput{
 		Key:    &oldKey,
 		Bucket: &oldBucket,
@@ -191,9 +220,11 @@ func (s *defaultS3Wrapper) MoveObject(ctx context.Context, oldBucket, oldKey, ne
 	return out, nil
 }
 
-func (s *defaultS3Wrapper) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+func (s *DefaultS3Wrapper) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
 	// In AWS SDK v2, we need to handle pagination manually
-	// Create a paginator to iterate through all pages
+	// Create a paginator to iterate through all pages. S3API satisfies the
+	// s3.ListObjectsV2APIClient interface implicitly because it declares
+	// the same ListObjectsV2 method.
 	paginator := s3.NewListObjectsV2Paginator(s.client, input)
 
 	// Collect all objects from all pages

--- a/pkg/rsstorage/servers/s3server/s3_service.go
+++ b/pkg/rsstorage/servers/s3server/s3_service.go
@@ -67,10 +67,13 @@ type DefaultS3Wrapper struct {
 // configuration values lets callers wrap or replace the AWS SDK client with
 // their own implementation, which is useful for testing and for layering on
 // behaviors such as Object Lock-aware deletes.
-func NewS3Wrapper(client S3API) *DefaultS3Wrapper {
+func NewS3Wrapper(client S3API) (*DefaultS3Wrapper, error) {
+	if client == nil {
+		return nil, errors.New("unable to create S3 wrapper, S3 client is nil")
+	}
 	return &DefaultS3Wrapper{
 		client: client,
-	}
+	}, nil
 }
 
 func (s *DefaultS3Wrapper) KmsEncrypted() bool {
@@ -233,7 +236,7 @@ func (s *DefaultS3Wrapper) ListObjects(ctx context.Context, input *s3.ListObject
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error encountered while listing objects: %w", err)
 		}
 
 		// Collect all objects from this page
@@ -241,9 +244,8 @@ func (s *DefaultS3Wrapper) ListObjects(ctx context.Context, input *s3.ListObject
 	}
 
 	// Return all collected objects in a single response
-	isTruncated := false
 	return &s3.ListObjectsV2Output{
 		Contents:    allObjects,
-		IsTruncated: &isTruncated,
+		IsTruncated: new(false),
 	}, nil
 }

--- a/pkg/rsstorage/servers/s3server/s3_service_test.go
+++ b/pkg/rsstorage/servers/s3server/s3_service_test.go
@@ -19,6 +19,16 @@ type S3WrapperSuite struct{}
 
 var _ = check.Suite(&S3WrapperSuite{})
 
+// newTestS3Client constructs a *s3.Client wired through the supplied
+// http.Client so tests can stub responses with httpmock.
+func newTestS3Client(httpClient *http.Client) *s3.Client {
+	return s3.New(s3.Options{
+		Region:      "us-east-1",
+		HTTPClient:  httpClient,
+		Credentials: aws.AnonymousCredentials{},
+	})
+}
+
 func (s *S3WrapperSuite) TestCreateBucket(c *check.C) {
 	client := http.Client{}
 	httpmock.ActivateNonDefault(&client)
@@ -30,19 +40,12 @@ func (s *S3WrapperSuite) TestCreateBucket(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			HTTPClient:  &client,
-			Credentials: aws.AnonymousCredentials{},
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
 	input := &s3.CreateBucketInput{
 		Bucket: aws.String("foo"),
 	}
-	_, err = wrapper.CreateBucket(context.Background(), input)
+	_, err := wrapper.CreateBucket(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -58,20 +61,13 @@ func (s *S3WrapperSuite) TestHeadObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
 	input := &s3.HeadObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err = wrapper.HeadObject(context.Background(), input)
+	_, err := wrapper.HeadObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -88,20 +84,13 @@ func (s *S3WrapperSuite) TestGetObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err = wrapper.GetObject(context.Background(), input)
+	_, err := wrapper.GetObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -118,20 +107,13 @@ func (s *S3WrapperSuite) TestDeleteObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err = wrapper.DeleteObject(context.Background(), input)
+	_, err := wrapper.DeleteObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -148,16 +130,9 @@ func (s *S3WrapperSuite) TestMoveObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
-	_, err = wrapper.MoveObject(context.Background(), "foo", "foo", "foo2", "newFoo")
+	_, err := wrapper.MoveObject(context.Background(), "foo", "foo", "foo2", "newFoo")
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -174,16 +149,9 @@ func (s *S3WrapperSuite) TestCopyObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
-	_, err = wrapper.CopyObject(context.Background(), "foo", "foo", "foo2", "newFoo")
+	_, err := wrapper.CopyObject(context.Background(), "foo", "foo", "foo2", "newFoo")
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -215,14 +183,7 @@ func (s *S3WrapperSuite) TestListObjects(c *check.C) {
 	httpmock.RegisterResponder("GET", `https://no-sync.s3.us-east-1.amazonaws.com/?list-type=2&prefix=bin%2F3.5-xenial`,
 		httpmock.NewStringResponder(http.StatusNotFound, ``))
 
-	wrapper, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-			HTTPClient:  &client,
-		},
-	)
-	c.Assert(err, check.IsNil)
+	wrapper := NewS3Wrapper(newTestS3Client(&client))
 
 	ctx := context.Background()
 	bucket := "no-sync"
@@ -245,13 +206,10 @@ func (s *S3WrapperSuite) TestListObjects(c *check.C) {
 
 func (s *S3WrapperSuite) TestSetStorageS3Validate(c *check.C) {
 
-	svc, err := NewS3Wrapper(
-		s3.Options{
-			Region:      "us-east-1",
-			Credentials: aws.AnonymousCredentials{},
-		},
-	)
-	c.Assert(err, check.IsNil)
+	svc := NewS3Wrapper(s3.New(s3.Options{
+		Region:      "us-east-1",
+		Credentials: aws.AnonymousCredentials{},
+	}))
 
 	wn := &servertest.DummyWaiterNotifier{}
 	s3srv := NewStorageServer(StorageServerArgs{
@@ -263,6 +221,6 @@ func (s *S3WrapperSuite) TestSetStorageS3Validate(c *check.C) {
 		Notifier:  wn,
 	})
 
-	err = s3srv.(*StorageServer).Validate(context.Background())
+	err := s3srv.(*StorageServer).Validate(context.Background())
 	c.Assert(err, check.NotNil)
 }

--- a/pkg/rsstorage/servers/s3server/s3_service_test.go
+++ b/pkg/rsstorage/servers/s3server/s3_service_test.go
@@ -40,12 +40,14 @@ func (s *S3WrapperSuite) TestCreateBucket(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
 	input := &s3.CreateBucketInput{
 		Bucket: aws.String("foo"),
 	}
-	_, err := wrapper.CreateBucket(context.Background(), input)
+	_, err = wrapper.CreateBucket(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -61,13 +63,15 @@ func (s *S3WrapperSuite) TestHeadObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
 	input := &s3.HeadObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err := wrapper.HeadObject(context.Background(), input)
+	_, err = wrapper.HeadObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -84,13 +88,15 @@ func (s *S3WrapperSuite) TestGetObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err := wrapper.GetObject(context.Background(), input)
+	_, err = wrapper.GetObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -107,13 +113,15 @@ func (s *S3WrapperSuite) TestDeleteObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
 	input := &s3.DeleteObjectInput{
 		Bucket: aws.String("foo"),
 		Key:    aws.String("foo"),
 	}
-	_, err := wrapper.DeleteObject(context.Background(), input)
+	_, err = wrapper.DeleteObject(context.Background(), input)
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -130,9 +138,12 @@ func (s *S3WrapperSuite) TestMoveObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
-	_, err := wrapper.MoveObject(context.Background(), "foo", "foo", "foo2", "newFoo")
+	_, err = wrapper.MoveObject(context.Background(), "foo", "foo", "foo2", "newFoo")
+
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -149,9 +160,11 @@ func (s *S3WrapperSuite) TestCopyObject(c *check.C) {
 		httpmock.NewStringResponder(http.StatusNotFound, ``),
 	)
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
-	_, err := wrapper.CopyObject(context.Background(), "foo", "foo", "foo2", "newFoo")
+	_, err = wrapper.CopyObject(context.Background(), "foo", "foo", "foo2", "newFoo")
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.Contains(err.Error(), "StatusCode: 404"), check.Equals, true)
 }
@@ -183,7 +196,9 @@ func (s *S3WrapperSuite) TestListObjects(c *check.C) {
 	httpmock.RegisterResponder("GET", `https://no-sync.s3.us-east-1.amazonaws.com/?list-type=2&prefix=bin%2F3.5-xenial`,
 		httpmock.NewStringResponder(http.StatusNotFound, ``))
 
-	wrapper := NewS3Wrapper(newTestS3Client(&client))
+	wrapper, err := NewS3Wrapper(newTestS3Client(&client))
+	c.Assert(err, check.IsNil)
+	c.Assert(wrapper, check.NotNil)
 
 	ctx := context.Background()
 	bucket := "no-sync"
@@ -206,10 +221,12 @@ func (s *S3WrapperSuite) TestListObjects(c *check.C) {
 
 func (s *S3WrapperSuite) TestSetStorageS3Validate(c *check.C) {
 
-	svc := NewS3Wrapper(s3.New(s3.Options{
+	svc, err := NewS3Wrapper(s3.New(s3.Options{
 		Region:      "us-east-1",
 		Credentials: aws.AnonymousCredentials{},
 	}))
+	c.Assert(err, check.IsNil)
+	c.Assert(svc, check.NotNil)
 
 	wn := &servertest.DummyWaiterNotifier{}
 	s3srv := NewStorageServer(StorageServerArgs{
@@ -221,6 +238,6 @@ func (s *S3WrapperSuite) TestSetStorageS3Validate(c *check.C) {
 		Notifier:  wn,
 	})
 
-	err := s3srv.(*StorageServer).Validate(context.Background())
+	err = s3srv.(*StorageServer).Validate(context.Background())
 	c.Assert(err, check.NotNil)
 }


### PR DESCRIPTION
## About

This PR refactors the S3 backed storage server in `pkg/rsstorage/servers/s3server` to accept a AWS S3 client interface for instantiation. This is part of a bugfix for https://github.com/rstudio/package-manager/issues/17944 that resulted in `S3 PutObject` operations to fail if the S3 bucket used for the storage server had Object Lock enabled. This was a result of upgrading from the deprecated AWS Go SDK to the latest AWS Go SDK, which handles constructing configurations and included default options differently than the deprecated SDK. This resulted in the `RequestChecksumCalculation` being unset, when it needed to be set to `RequestChecksumCalculationWhenSupported` when Object Lock is enabled for the underlying PR bucket.

## Fixes

https://github.com/rstudio/package-manager/issues/17944

## Summary of changes

- Added the `S3API` interface as a subset of only the required methods of the AWS S3 client interface.
- Updated `NewEncryptedS3Wrapper()` to accept the `S3API` interface instead of S3 Options
- Updated `NewS3Wrapper()` to accept an `S3API` interface that is intended to be satisfied by the S3 client interface
- Pivoted `platform-lib/rsstorage` to accept a S3 client for instantiation and leave S3 configuration to consumers of the package
- Updated functions in `pkg/rsstorage/servers/s3server` to accept the new interfaces but return concrete types as to avoid confusion