### PR TITLE
Recover cluster leader from Postgres failover

### DIFF
--- a/pkg/rselection/impls/pgx/leader.go
+++ b/pkg/rselection/impls/pgx/leader.go
@@ -53,6 +53,19 @@ type PgxLeader struct {
 	pingSuccess     bool
 	pingSuccessLock sync.RWMutex
 
+	// stepDownTimeout is the duration of continuous cluster-integrity failure
+	// after which the leader steps down so a fresh election can occur. Zero
+	// disables step-down (legacy behavior).
+	stepDownTimeout time.Duration
+
+	// unhealthySince is the time the leader most recently entered an unhealthy
+	// state, or the zero value when currently healthy. Only accessed from the
+	// lead() goroutine.
+	unhealthySince time.Time
+
+	// now returns the current time; overridable in tests. Use timeNow().
+	now func() time.Time
+
 	// Stores information about active nodes and ping times
 	nodes map[string]*electiontypes.ClusterNode
 	mutex sync.RWMutex
@@ -60,6 +73,7 @@ type PgxLeader struct {
 	// Used for testing
 	loopAwareChTEST    chan bool
 	pingResponseChTEST chan bool
+	setClockTEST       func(time.Time)
 }
 
 type PgxLeaderConfig struct {
@@ -75,23 +89,26 @@ type PgxLeaderConfig struct {
 	PingInterval    time.Duration
 	SweepInterval   time.Duration
 	MaxPingAge      time.Duration
+	StepDownTimeout time.Duration
 }
 
 func NewPgxLeader(cfg PgxLeaderConfig) *PgxLeader {
 	return &PgxLeader{
-		store:       cfg.Store,
-		awb:         cfg.Broadcaster,
-		notify:      cfg.Notifier,
-		taskHandler: cfg.TaskHandler,
-		chLeader:    cfg.LeaderChannel,
-		chFollower:  cfg.FollowerChannel,
-		chMessages:  cfg.MessagesChannel,
-		address:     cfg.Address,
-		stop:        cfg.StopChan,
-		ping:        cfg.PingInterval,
-		sweep:       cfg.SweepInterval,
-		maxPingAge:  cfg.MaxPingAge,
-		mutex:       sync.RWMutex{},
+		store:           cfg.Store,
+		awb:             cfg.Broadcaster,
+		notify:          cfg.Notifier,
+		taskHandler:     cfg.TaskHandler,
+		chLeader:        cfg.LeaderChannel,
+		chFollower:      cfg.FollowerChannel,
+		chMessages:      cfg.MessagesChannel,
+		address:         cfg.Address,
+		stop:            cfg.StopChan,
+		ping:            cfg.PingInterval,
+		sweep:           cfg.SweepInterval,
+		maxPingAge:      cfg.MaxPingAge,
+		stepDownTimeout: cfg.StepDownTimeout,
+		now:             time.Now,
+		mutex:           sync.RWMutex{},
 	}
 }
 
@@ -391,4 +408,14 @@ func (p *PgxLeader) unsuccessfulPing() bool {
 	p.pingSuccessLock.RLock()
 	defer p.pingSuccessLock.RUnlock()
 	return !p.pingSuccess
+}
+
+// timeNow returns the current time, using the injectable p.now when set. This
+// keeps PgxLeader instances constructed as struct literals (e.g., in tests)
+// safe to use without setting now.
+func (p *PgxLeader) timeNow() time.Time {
+	if p.now != nil {
+		return p.now()
+	}
+	return time.Now()
 }

--- a/pkg/rselection/impls/pgx/leader.go
+++ b/pkg/rselection/impls/pgx/leader.go
@@ -192,6 +192,10 @@ func (p *PgxLeader) lead(ctx context.Context, pingTick, sweepTick <-chan time.Ti
 			go p.pingNodes(ctx)
 		case <-sweepTick:
 			p.sweepNodes()
+			if p.evaluateHealth() {
+				slog.Error("Leader stepping down after sustained cluster integrity failure; a new election will occur", "timeout", p.stepDownTimeout)
+				return
+			}
 		case vCh := <-p.taskHandler.Verify():
 			p.verify(vCh)
 		case <-logTickCh:
@@ -264,6 +268,38 @@ func (p *PgxLeader) clusterIntegrityErr() error {
 	}
 
 	return nil
+}
+
+// evaluateHealth runs the cluster integrity check and tracks how long the
+// leader has been unhealthy. It returns true when the leader should step down:
+// the cluster has been continuously unhealthy for at least stepDownTimeout
+// (when that timeout is non-zero). Called from the lead() goroutine only.
+func (p *PgxLeader) evaluateHealth() bool {
+	err := p.clusterIntegrityErr()
+	if err == nil {
+		p.unhealthySince = time.Time{}
+		return false
+	}
+
+	if p.unhealthySince.IsZero() {
+		p.unhealthySince = p.timeNow()
+	}
+	dur := p.timeNow().Sub(p.unhealthySince)
+
+	// Treat brief mismatches (e.g., a rolling restart) as routine; escalate only
+	// once the condition is sustained. When step-down is disabled, stay at debug
+	// to avoid per-tick error spam since no recovery action will be taken.
+	switch {
+	case p.stepDownTimeout == 0:
+		slog.Debug("Cluster integrity check failing", "error", err, "unhealthyFor", dur)
+		return false
+	case dur < p.stepDownTimeout/2:
+		slog.Debug("Cluster integrity check failing; may be transient", "error", err, "unhealthyFor", dur)
+	default:
+		slog.Error("Cluster integrity check failing", "error", err, "unhealthyFor", dur)
+	}
+
+	return dur >= p.stepDownTimeout
 }
 
 // verify gates a scheduled task on cluster health. It responds true on the

--- a/pkg/rselection/impls/pgx/leader.go
+++ b/pkg/rselection/impls/pgx/leader.go
@@ -254,7 +254,7 @@ func (p *PgxLeader) clusterIntegrityErr() error {
 	// leader re-adds itself via its self-ping, so pruning it is self-healing.
 	for key := range p.nodes {
 		if _, ok := storeKeys[key]; !ok {
-			slog.Debug("Leader pruning node no longer present in store", "node", key)
+			slog.Info("Leader pruning node no longer present in store", "node", key)
 			delete(p.nodes, key)
 		}
 	}

--- a/pkg/rselection/impls/pgx/leader.go
+++ b/pkg/rselection/impls/pgx/leader.go
@@ -218,58 +218,64 @@ func (p *PgxLeader) info() string {
 	return fmt.Sprintf("Cluster nodes:\n  %s", strings.Join(nodes, "\n  "))
 }
 
-// verify ensures that the in-memory node list matches the store list. We do
-// this to ensure that the cluster is healthy before running scheduled tasks.
-// This helps to prevent split-brain issues in the cluster.
-//
-//  1. The task handler is ready to run a scheduled task.
-//  2. The task handler sends a `chan bool` to its verify channel.
-//  3. We receive the `chan bool` here and:
-//     a. Verify that the cluster is healthy.
-//     b. Respond with `true` over the channel if the cluster is healthy.
-//  4. The task handler runs the scheduled task when the cluster is healthy.
-func (p *PgxLeader) verify(vCh chan bool) {
-	var err error
-
-	// Upon exit, notify channel with `true` or `false` depending upon error status
-	defer func(err *error) {
-		if *err != nil {
-			// TODO this should be worded better because sometimes this error is normal and expected,
-			// e.g. when restarting a cluster node and the node list is temporarily out of sync:
-			// Error verifying cluster integrity: node list length differs. Store node count 3 does not match leader count 2
-			// It would be great to be able to distinguish between expected/unexpected errors here and log accordingly.
-			slog.Error("Error verifying cluster integrity", "error", *err)
-			vCh <- false
-		} else {
-			vCh <- true
-		}
-	}(&err)
-
+// clusterIntegrityErr reports whether the leader is in contact with every node
+// the store considers part of the cluster, returning nil when healthy. As a
+// side effect it reconciles the in-memory node map asymmetrically: nodes that
+// have left the store are pruned (always safe), but store-only nodes are NOT
+// added here. Reachable nodes are re-added by handlePingResponse when they
+// answer a ping, which preserves the split-brain guarantee — the leader only
+// reports healthy once it is actually in contact with every registered node.
+func (p *PgxLeader) clusterIntegrityErr() error {
 	if p.unsuccessfulPing() {
-		err = fmt.Errorf("error pinging follower nodes")
-		return
+		return fmt.Errorf("error pinging follower nodes")
 	}
 
-	// Enumerate nodes recorded in database
 	nodes, err := p.store.Nodes()
 	if err != nil {
-		err = fmt.Errorf("error retrieving cluster node list for verification: %s", err)
-		return
+		return fmt.Errorf("error retrieving cluster node list for verification: %w", err)
 	}
 
-	// Ensure in-memory node list length matches store
-	if len(nodes) != len(p.nodes) {
-		err = fmt.Errorf("node list length differs. Store node count %d does not match leader count %d", len(nodes), len(p.nodes))
-		return
-	}
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 
-	// Ensure in-memory node list matches store list
+	// Build the set of node keys the store considers part of the cluster.
+	storeKeys := make(map[string]struct{}, len(nodes))
 	for _, node := range nodes {
-		if _, ok := p.nodes[node.Key()]; !ok {
-			err = fmt.Errorf("node %s with IP %s from store not known by leader", node.Name, node.IP)
-			return
+		storeKeys[node.Key()] = struct{}{}
+	}
+
+	// Prune in-memory nodes that are no longer present in the store.
+	// Unlike sweepNodes, we do not exempt the leader's own key here: the store
+	// includes the leader, and even if a transient store read omitted it the
+	// leader re-adds itself via its self-ping, so pruning it is self-healing.
+	for key := range p.nodes {
+		if _, ok := storeKeys[key]; !ok {
+			slog.Debug("Leader pruning node no longer present in store", "node", key)
+			delete(p.nodes, key)
 		}
 	}
+
+	// Any store node still missing from memory means the leader is not yet in
+	// contact with a registered node.
+	for _, node := range nodes {
+		if _, ok := p.nodes[node.Key()]; !ok {
+			return fmt.Errorf("node %s with IP %s from store not known by leader", node.Name, node.IP)
+		}
+	}
+
+	return nil
+}
+
+// verify gates a scheduled task on cluster health. It responds true on the
+// channel when the cluster is healthy, false otherwise. Leveled alerting on
+// sustained failure lives in evaluateHealth, so this logs only at debug.
+func (p *PgxLeader) verify(vCh chan bool) {
+	if err := p.clusterIntegrityErr(); err != nil {
+		slog.Debug("Skipping scheduled task; cluster integrity check failed", "error", err)
+		vCh <- false
+		return
+	}
+	vCh <- true
 }
 
 // pingNodes sends a ping request out on the follower channel. All online cluster

--- a/pkg/rselection/impls/pgx/leader.go
+++ b/pkg/rselection/impls/pgx/leader.go
@@ -277,29 +277,32 @@ func (p *PgxLeader) clusterIntegrityErr() error {
 func (p *PgxLeader) evaluateHealth() bool {
 	err := p.clusterIntegrityErr()
 	if err == nil {
+		if !p.unhealthySince.IsZero() {
+			slog.Info("Cluster integrity recovered", "degradedFor", p.timeNow().Sub(p.unhealthySince))
+		}
 		p.unhealthySince = time.Time{}
 		return false
 	}
 
+	// Log the onset of an unhealthy episode once, at INFO, so it appears in
+	// default logs (and is available for a customer escalation) without raising
+	// the log level. Per-tick detail stays at debug to avoid noise on routine,
+	// self-healing mismatches such as a rolling restart. A sustained failure
+	// escalates to error, but only when step-down is enabled: a disabled leader
+	// takes no recovery action and would otherwise log error every tick forever.
 	if p.unhealthySince.IsZero() {
 		p.unhealthySince = p.timeNow()
+		slog.Info("Cluster integrity check failing", "error", err)
 	}
 	dur := p.timeNow().Sub(p.unhealthySince)
 
-	// Treat brief mismatches (e.g., a rolling restart) as routine; escalate only
-	// once the condition is sustained. When step-down is disabled, stay at debug
-	// to avoid per-tick error spam since no recovery action will be taken.
-	switch {
-	case p.stepDownTimeout == 0:
+	if p.stepDownTimeout > 0 && dur >= p.stepDownTimeout/2 {
+		slog.Error("Cluster integrity check still failing", "error", err, "unhealthyFor", dur)
+	} else {
 		slog.Debug("Cluster integrity check failing", "error", err, "unhealthyFor", dur)
-		return false
-	case dur < p.stepDownTimeout/2:
-		slog.Debug("Cluster integrity check failing; may be transient", "error", err, "unhealthyFor", dur)
-	default:
-		slog.Error("Cluster integrity check failing", "error", err, "unhealthyFor", dur)
 	}
 
-	return dur >= p.stepDownTimeout
+	return p.stepDownTimeout > 0 && dur >= p.stepDownTimeout
 }
 
 // verify gates a scheduled task on cluster health. It responds true on the

--- a/pkg/rselection/impls/pgx/leader_recovery_test.go
+++ b/pkg/rselection/impls/pgx/leader_recovery_test.go
@@ -1,0 +1,75 @@
+package pgxelection
+
+// Copyright (C) 2026 by Posit Software, PBC
+
+import (
+	"errors"
+	"time"
+
+	"gopkg.in/check.v1"
+
+	"github.com/rstudio/platform-lib/v4/pkg/rselection/electiontypes"
+)
+
+// RecoverySuite holds Postgres-free unit tests for the leader's integrity
+// check and step-down logic. It intentionally does not use the shared pgx
+// pool, so it runs even under `go test -short`.
+type RecoverySuite struct{}
+
+var _ = check.Suite(&RecoverySuite{})
+
+func newTestLeader(store ClusterPgStore, nodes map[string]*electiontypes.ClusterNode) *PgxLeader {
+	return &PgxLeader{
+		store:       store,
+		notify:      FakePgNotifier{},
+		nodes:       nodes,
+		pingSuccess: true,
+	}
+}
+
+// A node present in memory but absent from the store is pruned, and the check
+// then reports healthy.
+func (s *RecoverySuite) TestIntegrityPrunesDepartedNode(c *check.C) {
+	store := &fakeStore{nodes: map[string]*electiontypes.ClusterNode{
+		"a": {Name: "a", IP: "10.0.0.1"},
+	}}
+	leader := newTestLeader(store, map[string]*electiontypes.ClusterNode{
+		"a_10.0.0.1": {Name: "a", IP: "10.0.0.1"},
+		"b_10.0.0.2": {Name: "b", IP: "10.0.0.2"}, // not in store; should be pruned
+	})
+
+	c.Assert(leader.clusterIntegrityErr(), check.IsNil)
+	c.Assert(leader.nodes, check.HasLen, 1)
+	_, ok := leader.nodes["b_10.0.0.2"]
+	c.Assert(ok, check.Equals, false)
+}
+
+// A node present in the store but absent from memory is an error and is NOT
+// added to memory (it must be re-added by a real ping response).
+func (s *RecoverySuite) TestIntegrityStoreOnlyNodeErrorsWithoutAdding(c *check.C) {
+	store := &fakeStore{nodes: map[string]*electiontypes.ClusterNode{
+		"a": {Name: "a", IP: "10.0.0.1"},
+		"b": {Name: "b", IP: "10.0.0.2"},
+	}}
+	leader := newTestLeader(store, map[string]*electiontypes.ClusterNode{
+		"a_10.0.0.1": {Name: "a", IP: "10.0.0.1"},
+	})
+
+	c.Assert(leader.clusterIntegrityErr(), check.NotNil)
+	_, ok := leader.nodes["b_10.0.0.2"]
+	c.Assert(ok, check.Equals, false)
+}
+
+func (s *RecoverySuite) TestIntegrityUnsuccessfulPingErrors(c *check.C) {
+	leader := newTestLeader(&fakeStore{}, map[string]*electiontypes.ClusterNode{})
+	leader.pingSuccess = false
+	c.Assert(leader.clusterIntegrityErr(), check.NotNil)
+}
+
+func (s *RecoverySuite) TestIntegrityStoreErrorErrors(c *check.C) {
+	store := &fakeStore{err: errors.New("db down")}
+	leader := newTestLeader(store, map[string]*electiontypes.ClusterNode{})
+	c.Assert(leader.clusterIntegrityErr(), check.NotNil)
+}
+
+var _ = time.Now // retained; used by later step-down tests in this file

--- a/pkg/rselection/impls/pgx/leader_recovery_test.go
+++ b/pkg/rselection/impls/pgx/leader_recovery_test.go
@@ -72,4 +72,72 @@ func (s *RecoverySuite) TestIntegrityStoreErrorErrors(c *check.C) {
 	c.Assert(leader.clusterIntegrityErr(), check.NotNil)
 }
 
-var _ = time.Now // retained; used by later step-down tests in this file
+// healthyLeader returns a leader whose integrity check passes (ping ok, store
+// matches memory) with an injectable clock starting at t.
+func healthyLeader(t time.Time, stepDown time.Duration) *PgxLeader {
+	store := &fakeStore{nodes: map[string]*electiontypes.ClusterNode{
+		"a": {Name: "a", IP: "10.0.0.1"},
+	}}
+	leader := newTestLeader(store, map[string]*electiontypes.ClusterNode{
+		"a_10.0.0.1": {Name: "a", IP: "10.0.0.1"},
+	})
+	leader.stepDownTimeout = stepDown
+	cur := t
+	leader.now = func() time.Time { return cur }
+	leader.setClockTEST = func(nt time.Time) { cur = nt }
+	return leader
+}
+
+func (s *RecoverySuite) TestStepDownAfterSustainedFailure(c *check.C) {
+	start := time.Unix(1_000_000, 0)
+	leader := healthyLeader(start, 30*time.Second)
+
+	// Healthy: no step-down, unhealthySince stays zero.
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+	c.Assert(leader.unhealthySince.IsZero(), check.Equals, true)
+
+	// Force unhealthy via failing pings.
+	leader.pingSuccess = false
+
+	// First failure records the time but does not step down.
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+	c.Assert(leader.unhealthySince.Equal(start), check.Equals, true)
+
+	// Still within the timeout window.
+	leader.setClockTEST(start.Add(29 * time.Second))
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+
+	// At/after the timeout, step down.
+	leader.setClockTEST(start.Add(30 * time.Second))
+	c.Assert(leader.evaluateHealth(), check.Equals, true)
+}
+
+func (s *RecoverySuite) TestStepDownResetsOnRecovery(c *check.C) {
+	start := time.Unix(1_000_000, 0)
+	leader := healthyLeader(start, 30*time.Second)
+
+	leader.pingSuccess = false
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+	c.Assert(leader.unhealthySince.IsZero(), check.Equals, false)
+
+	// Recover before the timeout elapses.
+	leader.pingSuccess = true
+	leader.setClockTEST(start.Add(10 * time.Second))
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+	c.Assert(leader.unhealthySince.IsZero(), check.Equals, true)
+
+	// A later, separate failure must not immediately trip the timeout.
+	leader.pingSuccess = false
+	leader.setClockTEST(start.Add(11 * time.Second))
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+}
+
+func (s *RecoverySuite) TestStepDownDisabledByZeroTimeout(c *check.C) {
+	start := time.Unix(1_000_000, 0)
+	leader := healthyLeader(start, 0) // disabled
+	leader.pingSuccess = false
+
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+	leader.setClockTEST(start.Add(100 * time.Hour))
+	c.Assert(leader.evaluateHealth(), check.Equals, false)
+}

--- a/pkg/rselection/impls/pgx/leader_test.go
+++ b/pkg/rselection/impls/pgx/leader_test.go
@@ -252,6 +252,14 @@ func (s *LeaderSuite) TestLeaderLeadInternal(c *check.C) {
 	c.Assert(fakeNotifier.msgs, check.HasLen, 4)
 	c.Assert(leader.nodes, check.HasLen, 2)
 
+	// The leader now reconciles the in-memory map against the store on every
+	// sweep (via evaluateHealth), so seed the store with the node that should
+	// survive: "one" has a stale ping and is swept; "two" remains and is in the
+	// store, so it is neither swept nor pruned.
+	cstore.nodes = map[string]*electiontypes.ClusterNode{
+		"two": {Name: "two", IP: "192.168.50.12"},
+	}
+
 	// Sweep
 	wait(loopCh, func() { sweepTick <- time.Now() })
 	c.Assert(leader.nodes, check.HasLen, 1)

--- a/pkg/rselection/impls/pgx/leader_test.go
+++ b/pkg/rselection/impls/pgx/leader_test.go
@@ -295,42 +295,33 @@ func (s *LeaderSuite) TestLeaderLeadInternal(c *check.C) {
 	c.Assert(string(fakeNotifier.msgs[4].msg), check.Matches, ".+65db0d7d-8db1-4fa8-bc2a-58fad248507f.+")
 	c.Assert(len(fakeNotifier.msgs[4].msg), check.Equals, 247)
 
-	// Verify health (store has wrong node count)
+	// Verify health (store matches memory exactly -> healthy)
 	cstore.nodes = map[string]*electiontypes.ClusterNode{
-		"follower": {
-			Name: "follower",
-			IP:   "192.168.50.11",
-		},
+		"two":      {Name: "two", IP: "192.168.50.12"},
+		"follower": {Name: "follower", IP: "192.168.50.11"},
 	}
 	vCh := make(chan bool)
 	verifyCh <- vCh
-	ok := <-vCh
-	c.Assert(ok, check.Equals, false)
+	c.Assert(<-vCh, check.Equals, true)
 
-	// Verify health (store throws error)
+	// Verify health (a node left the store -> pruned from memory, still healthy)
+	cstore.nodes = map[string]*electiontypes.ClusterNode{
+		"follower": {Name: "follower", IP: "192.168.50.11"},
+	}
+	verifyCh <- vCh
+	c.Assert(<-vCh, check.Equals, true)
+	c.Assert(leader.nodes, check.HasLen, 1)
+
+	// Verify health (store has a node memory lacks -> unhealthy)
+	cstore.nodes["three"] = &electiontypes.ClusterNode{Name: "three", IP: "192.168.50.13"}
+	verifyCh <- vCh
+	c.Assert(<-vCh, check.Equals, false)
+
+	// Verify health (store throws error -> unhealthy)
 	cstore.err = errors.New("store error")
 	verifyCh <- vCh
-	ok = <-vCh
-	c.Assert(ok, check.Equals, false)
-
-	// Verify health (store has wrong nodes)
+	c.Assert(<-vCh, check.Equals, false)
 	cstore.err = nil
-	cstore.nodes["three"] = &electiontypes.ClusterNode{}
-	verifyCh <- vCh
-	ok = <-vCh
-	c.Assert(ok, check.Equals, false)
-
-	// Verify health (OK)
-	delete(cstore.nodes, "three")
-	cstore.nodes["two"] = &electiontypes.ClusterNode{
-		Name: "two",
-		IP:   "192.168.50.12",
-		Ping: time.Now(),
-	}
-
-	verifyCh <- vCh
-	ok = <-vCh
-	c.Assert(ok, check.Equals, true)
 
 	// Stop
 	close(stop)


### PR DESCRIPTION
## Problem

When the Postgres database behind a multi-node PPM cluster fails over (e.g. an AWS RDS maintenance window), `PgxLeader` can wedge: it keeps emitting pings and considers itself leader, but stops running scheduled work. Two collaborating bugs cause this:

1. `Lead()` never returns on persistent failure — its only exit was the stop channel, so the supervisor's leader→follower recovery path was never taken.
2. The in-memory node map drifts from the store during the outage and `verify()`'s strict length check then fails permanently, silently skipping every scheduled task.

This is the underlying cause of repeated production incidents (`node list length differs ...`) downstream in Posit Package Manager (rstudio/package-manager#17889).

## Changes

- **`clusterIntegrityErr()`** — a shared cluster-integrity check that reconciles the in-memory node map *asymmetrically*: prune nodes that have left the store (safe), but never add store-only nodes. Reachable nodes are re-added by `handlePingResponse` when they answer a ping, which preserves the split-brain guard. `verify()` becomes a thin wrapper over it.
- **`evaluateHealth()` + time-based step-down** — evaluated on the existing sweep tick. After `StepDownTimeout` of continuous integrity failure the leader returns from `lead()`, so `Lead()` returns nil and the consumer's supervisor re-elects. `StepDownTimeout == 0` disables step-down (legacy behavior).
- **Leveled logging** — transient mismatches (rolling restarts) log at debug; sustained failure logs at error; the disabled mode stays at debug to avoid per-tick spam.

New config field: `PgxLeaderConfig.StepDownTimeout`.

## Tests

New Postgres-free `RecoverySuite` covers the asymmetric reconcile (prune vs. error-without-adding), the step-down threshold boundary, reset-on-recovery, and the disabled (`0`) case. The existing `TestLeaderLeadInternal` integrity block was updated to the new semantics. Full Postgres-backed suite runs in CI.