### PR TITLE
Explain unexpected work recursion before logging fatally

### DIFF
--- a/pkg/rsqueue/queue/work.go
+++ b/pkg/rsqueue/queue/work.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime/debug"
 	"time"
 )
 
@@ -86,9 +87,11 @@ func (a *OptionalRecurser) OptionallyRecurse(ctx context.Context, run func()) {
 			// Are we expecting recursion?
 			allowed := ctx.Value(CtxAllowsRecursion)
 			if allowed == nil {
-				msg := fmt.Sprintf("Work with type %d attempted recursion without being marked for recursion", r.WorkType)
+				msg := fmt.Sprintf("Work with type %d attempted recursion without being marked for recursion. "+
+					"The work's context reached a nested queue operation without ContextWithExpectedRecursion; "+
+					"mark the context in the work's runner.", r.WorkType)
 				if a.fatalRecurseCheck {
-					log.Fatal(msg)
+					log.Fatalf("%s Exiting because FatalRecurseCheck is enabled. Recursion stack:\n%s", msg, debug.Stack())
 				} else {
 					log.Println(msg)
 				}


### PR DESCRIPTION
Found while debugging a downstream product that exited with only `Work with type 64 attempted recursion without being marked for recursion`. The message names the work type but not why the process died or where the recursion came from, so locating the unmarked runner took an investigation that a stack trace would have answered immediately.

Changes in `OptionallyRecurse`:

- Both log paths now state the cause and the fix: the work's context reached a nested queue operation without `ContextWithExpectedRecursion`, and the runner should mark its context.
- The fatal path says the exit is caused by `FatalRecurseCheck` being enabled and includes `debug.Stack()` to locate the unmarked call chain.
- No functional change: unmarked recursion still proceeds through `r.Recurse` as before.

Testing: `go test ./pkg/rsqueue/queue/` passes. Log-output change only.
