### PR TITLE
fix(rsqueue): buffer PollAddress errCh to prevent goroutine leak on abandoned poll

### DIFF
--- a/pkg/rsqueue/impls/database/queue.go
+++ b/pkg/rsqueue/impls/database/queue.go
@@ -246,7 +246,13 @@ func (q *DatabaseQueue) IsAddressInQueue(ctx context.Context, address string) (b
 }
 
 func (q *DatabaseQueue) PollAddress(ctx context.Context, address string) <-chan error {
-	errCh := make(chan error)
+	// Buffered by 1 so the polling goroutine's single error send below can never
+	// block, even if the caller has stopped receiving (e.g. its request context
+	// was canceled and it returned). An unbuffered channel here leaked one
+	// goroutine per abandoned poll, parked forever on the send
+	// (rstudio/package-manager#19008). The goroutine sends at most one value
+	// before closing, so a single slot is sufficient.
+	errCh := make(chan error, 1)
 
 	go func() {
 		var done, ticked bool

--- a/pkg/rsqueue/impls/database/queue_test.go
+++ b/pkg/rsqueue/impls/database/queue_test.go
@@ -478,6 +478,48 @@ func (s *QueueSuite) TestPollErr(c *check.C) {
 	c.Assert(s.store.polled, check.Equals, 1)
 }
 
+// TestPollErrAbandonedReceiver reproduces the goroutine leak from
+// rstudio/package-manager#19008: when the caller stops receiving from the
+// channel returned by PollAddress (e.g. its request context is canceled), the
+// poll goroutine must still be able to complete and exit rather than parking
+// forever on a send that no one will receive. Here we call PollAddress and
+// never read from errCh; leaktest.Check then asserts the poll goroutine has
+// exited. With an unbuffered errCh the goroutine blocks on `errCh <- err` and
+// this fails; with a buffered errCh it sends, closes, and returns.
+func (s *QueueSuite) TestPollErrAbandonedReceiver(c *check.C) {
+	// NOTE: this uses the correct leaktest form — `defer leaktest.Check(c)()`
+	// (Check returns a checker func that must be invoked at return). The other
+	// tests in this file call `defer leaktest.Check(c)` without the trailing
+	// (), which discards the checker and never actually asserts; fixing those
+	// is out of scope here.
+	defer leaktest.Check(c)()
+
+	s.store.pollErr = errors.New("horrible error")
+	q := &DatabaseQueue{
+		store:               s.store,
+		addressPollInterval: time.Millisecond * 5,
+		subscribe:           make(chan broadcaster.Subscription),
+		unsubscribe:         make(chan (<-chan listener.Notification)),
+		wrapper:             &fakeWrapper{},
+	}
+
+	queueMsgs := make(chan listener.Notification)
+	workMsgs := make(chan listener.Notification)
+	chunkMsgs := make(chan listener.Notification)
+	defer close(queueMsgs)
+	defer close(workMsgs)
+	defer close(chunkMsgs)
+
+	stopper := make(chan bool)
+	defer func() { stopper <- true }()
+	go q.broadcast(stopper, queueMsgs, workMsgs, chunkMsgs)
+
+	// Start polling but never receive from the returned channel, simulating a
+	// caller that gave up (context canceled). The poll goroutine hits the error
+	// path and must not leak.
+	_ = q.PollAddress(context.Background(), "something")
+}
+
 func (s *QueueSuite) TestPollLockErr(c *check.C) {
 	defer leaktest.Check(c)
 


### PR DESCRIPTION
## Summary

`DatabaseQueue.PollAddress` returned an **unbuffered** error channel. Its polling goroutine has exactly one send (`errCh <- err` on a non-lock store error). When the caller stops receiving — e.g. its request context is canceled and it returns from the `select { case <-ctx.Done(): ... case err = <-errCh: }` wait in `rscache/file.go` — that send parks **forever**, leaking one goroutine per abandoned poll. Under bulk request pile-ups these accumulate and degrade the server.

Downstream this is rstudio/package-manager#19008 (blocked `PollAddress` senders observed in production goroutine dumps).

## Fix

Buffer the channel by 1 (`make(chan error, 1)`). The goroutine sends at most one value before closing, so a single slot guarantees the send never blocks regardless of whether a receiver is still present. This mirrors the "guarantee the sender can always complete" approach rather than depending on a live receiver.

- No behavior change for a live waiter: it still reads the single error (or the close) exactly as before. Errors are neither newly surfaced nor swallowed.
- The only production caller is `rscache/file.go` (`fileCache.get`/`Get`); `RecordingProducer.PollAddress` is a test double and unaffected.

## Test

Adds `TestPollErrAbandonedReceiver` — starts a poll, never receives from the returned channel, and asserts (via `leaktest`) the poll goroutine has exited. RED before the fix (leaked goroutine parked at the send), GREEN after.

Note: the new test uses the correct `defer leaktest.Check(c)()` form. The existing poll tests call `defer leaktest.Check(c)` **without** invoking the returned checker, so their leak assertion is currently a no-op — flagged here; fixing those is out of scope for this change.

`go test ./pkg/rsqueue/... ./pkg/rscache/...` and `go vet` pass.

## Downstream

Package Manager (#19008) vendors this module; once released (a patch tag, e.g. `v4.3.1`), PPM will bump `go.mod` + `go mod vendor` and add a `### Fixed` NEWS entry referencing #19008.
