### PR TITLE
Add prefix-scoped enumeration to rsstorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tempvendor
 
 # Database
 data
+
+# Compose logs written into the repo root by the test-integration cleanup trap
+test-integration-*.log

--- a/pkg/rsstorage/internal/integration_test/integration_test.go
+++ b/pkg/rsstorage/internal/integration_test/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -307,6 +308,80 @@ func (s *StorageIntegrationSuite) CheckFileGone(c *check.C, server rsstorage.Sto
 	ok, _, _, _, err := server.Check(context.Background(), "", address)
 	c.Check(err, check.IsNil)
 	c.Check(ok, check.Equals, false)
+}
+
+// TestEnumeratePrefix exercises prefix-scoped enumeration against every real
+// backend -- Postgres, MinIO and the filesystem -- rather than against fakes.
+//
+// Two things here are only testable at this level. The Postgres implementation
+// pushes the prefix into a LIKE query, so its SQL and its escaping of LIKE
+// metacharacters ("_" appears in every key below) never execute in a unit test.
+// And NewServerSet wraps each backend in a MetadataStorageServer, so this also
+// proves the decorator forwards the interface: embedding the StorageServer
+// interface does not promote EnumeratePrefix, so without explicit forwarding the
+// type assertion below fails and every caller silently loses prefix scoping.
+func (s *StorageIntegrationSuite) TestEnumeratePrefix(c *check.C) {
+	ctx := context.Background()
+	servers := s.NewServerSet(c, "prefix-enum", "")
+
+	for class, server := range servers {
+		slog.Info("Verify prefix enumeration", "server", class)
+
+		put := func(dir, address string) {
+			_, _, err := server.Put(ctx, func(w io.Writer) (string, string, error) {
+				_, writeErr := w.Write([]byte("data"))
+				return dir, address, writeErr
+			}, dir, address)
+			c.Assert(err, check.IsNil)
+		}
+
+		put("", "GIT_1_2_3.gob")
+		put("", "GIT_44_55_66.gob")
+		put("", "27_GIT_1_2_3.gob")
+		put("", "PACKAGES")
+		put("nested", "GIT_7_8_9.gob")
+
+		prefixEnumerator, ok := server.(rsstorage.PrefixEnumerator)
+		c.Assert(ok, check.Equals, true,
+			check.Commentf("%s server does not implement PrefixEnumerator; a wrapped server needs explicit forwarding", class))
+
+		items, err := prefixEnumerator.EnumeratePrefix(ctx, "GIT_")
+		c.Assert(err, check.IsNil)
+
+		keys := make([]string, 0, len(items))
+		for _, item := range items {
+			keys = append(keys, rsstorage.ItemKey(item.Dir, item.Address))
+		}
+		sort.Strings(keys)
+		// Only the root-level GIT_ keys. Not the version-prefixed one, not
+		// PACKAGES, and not nested/GIT_7_8_9.gob, whose key starts with "nested".
+		c.Check(keys, check.DeepEquals, []string{"GIT_1_2_3.gob", "GIT_44_55_66.gob"},
+			check.Commentf("server %s", class))
+
+		// A prefix that reaches into a directory.
+		items, err = prefixEnumerator.EnumeratePrefix(ctx, "nested/GIT_")
+		c.Assert(err, check.IsNil)
+		c.Assert(items, check.HasLen, 1, check.Commentf("server %s", class))
+		c.Check(items[0].Dir, check.Equals, "nested", check.Commentf("server %s", class))
+		c.Check(items[0].Address, check.Equals, "GIT_7_8_9.gob", check.Commentf("server %s", class))
+
+		// What comes out can go straight back in. On S3 this is the difference
+		// between EnumeratePrefix and Enumerate: Enumerate leaves the bucket
+		// prefix on Dir, and Remove joins it again, so a Remove built from its
+		// output addresses prefix/prefix/... and silently does nothing.
+		err = prefixEnumerator.(rsstorage.StorageServer).Remove(ctx, items[0].Dir, items[0].Address)
+		c.Assert(err, check.IsNil, check.Commentf("server %s", class))
+
+		items, err = prefixEnumerator.EnumeratePrefix(ctx, "nested/GIT_")
+		c.Assert(err, check.IsNil)
+		c.Check(items, check.HasLen, 0,
+			check.Commentf("%s: Remove reported success but the object survived", class))
+
+		// An unmatched prefix is empty, not an error.
+		items, err = prefixEnumerator.EnumeratePrefix(ctx, "NOPE_")
+		c.Assert(err, check.IsNil)
+		c.Check(items, check.HasLen, 0, check.Commentf("server %s", class))
+	}
 }
 
 func (s *StorageIntegrationSuite) TestMoving(c *check.C) {

--- a/pkg/rsstorage/prefix.go
+++ b/pkg/rsstorage/prefix.go
@@ -1,0 +1,90 @@
+package rsstorage
+
+// Copyright (C) 2026 by Posit Software, PBC
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/rstudio/platform-lib/v4/pkg/rsstorage/types"
+)
+
+// ErrPrefixEnumerationUnsupported is returned by EnumeratePrefix when the
+// underlying storage server cannot scope a listing by prefix. Callers should
+// treat it as "ask for less, or do without" rather than falling back to a full
+// Enumerate: the whole point of the prefix API is to avoid listing everything,
+// so a silent fallback reintroduces the cost the caller was avoiding.
+var ErrPrefixEnumerationUnsupported = errors.New("storage server does not support prefix enumeration")
+
+// PrefixEnumerator is implemented by storage servers that can list a subset of
+// their contents identified by a key prefix, without enumerating everything.
+//
+// It is deliberately a separate interface rather than a method on StorageServer.
+// StorageServer is a published surface with implementers outside this module, so
+// adding a method to it would be a breaking change requiring a major version
+// bump (see the release policy in README.md). Callers type-assert instead:
+//
+//	if pe, ok := server.(PrefixEnumerator); ok {
+//		items, err := pe.EnumeratePrefix(ctx, "SOME_PREFIX")
+//	}
+//
+// Every storage server in this module implements it. A decorator that wraps a
+// StorageServer must forward it explicitly; embedding the StorageServer
+// interface does not promote methods that interface does not declare, so the
+// type assertion above would otherwise fail on the wrapper and quietly lose the
+// optimization.
+type PrefixEnumerator interface {
+	// EnumeratePrefix returns every stored item whose key begins with prefix.
+	//
+	// A key is the item's Dir and Address joined with "/", or just Address for
+	// items at the root of the server. Prefixes are matched over that whole
+	// string and need not fall on a path boundary: the prefix "GIT_" matches the
+	// root-level key "GIT_1_2_3.gob", and the prefix "a/b" matches both "a/bc"
+	// and "a/b/c".
+	//
+	// An empty prefix is equivalent to Enumerate.
+	//
+	// Dir is relative to the root of the storage server, so a returned item can
+	// be passed straight back to Get, Check or Remove.
+	EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error)
+}
+
+// ItemKey returns the key that PrefixEnumerator matches against: the item's
+// directory and address joined with "/", or just the address at the root.
+func ItemKey(dir, address string) string {
+	if dir == "" {
+		return address
+	}
+	return dir + "/" + address
+}
+
+// KeyHasPrefix reports whether the item identified by dir and address is within
+// prefix.
+func KeyHasPrefix(dir, address, prefix string) bool {
+	return strings.HasPrefix(ItemKey(dir, address), prefix)
+}
+
+// SubtreeMayMatch reports whether a directory whose path relative to the storage
+// root is dir could contain any key matching prefix. It is the pruning test for
+// a tree walk: a false result means the whole subtree can be skipped.
+//
+// Two cases qualify. Either the prefix reaches down into this directory, so a
+// match may lie deeper ("a" when the prefix is "a/b/c"), or the directory is
+// itself already within the prefix, so everything below it matches ("GIT_x" when
+// the prefix is "GIT_"). The root, whose relative path is empty, always
+// qualifies.
+func SubtreeMayMatch(dir, prefix string) bool {
+	if dir == "" || prefix == "" {
+		return true
+	}
+	// The prefix descends into this directory. Compare against dir + "/" so that
+	// a sibling sharing a name prefix -- dir "ab" against prefix "a/b" -- does
+	// not look like a match.
+	if strings.HasPrefix(prefix, dir+"/") {
+		return true
+	}
+	// The prefix stops short of this directory's name, so the directory and
+	// everything under it is inside the prefix.
+	return strings.HasPrefix(dir, prefix)
+}

--- a/pkg/rsstorage/prefix_conformance_test.go
+++ b/pkg/rsstorage/prefix_conformance_test.go
@@ -1,0 +1,30 @@
+package rsstorage_test
+
+// Copyright (C) 2026 by Posit Software, PBC
+
+import (
+	"github.com/rstudio/platform-lib/v4/pkg/rsstorage"
+	"github.com/rstudio/platform-lib/v4/pkg/rsstorage/servers/file"
+	"github.com/rstudio/platform-lib/v4/pkg/rsstorage/servers/postgres"
+	"github.com/rstudio/platform-lib/v4/pkg/rsstorage/servers/s3server"
+)
+
+// Every storage server in this module must implement PrefixEnumerator.
+//
+// Callers reach it by type assertion, which fails silently: a server that
+// stopped implementing it would not break a build or fail a test, it would just
+// quietly fall back to whatever the caller does without prefix scoping -- for
+// PPM, skipping a cleanup, and in general re-listing an entire storage class.
+// These assertions turn that into a compile error.
+//
+// MetadataStorageServer is the case most likely to regress. It embeds the
+// StorageServer INTERFACE, and embedding an interface promotes only the methods
+// that interface declares, so it needs an explicit forwarding method and does
+// not get one for free.
+var (
+	_ rsstorage.PrefixEnumerator = (*file.StorageServer)(nil)
+	_ rsstorage.PrefixEnumerator = (*s3server.StorageServer)(nil)
+	_ rsstorage.PrefixEnumerator = (*postgres.StorageServer)(nil)
+	_ rsstorage.PrefixEnumerator = (*rsstorage.MetadataStorageServer)(nil)
+	_ rsstorage.PrefixEnumerator = (*rsstorage.DummyStorageServer)(nil)
+)

--- a/pkg/rsstorage/prefix_test.go
+++ b/pkg/rsstorage/prefix_test.go
@@ -1,0 +1,63 @@
+package rsstorage
+
+// Copyright (C) 2026 by Posit Software, PBC
+
+import (
+	"gopkg.in/check.v1"
+)
+
+// The gocheck entry point for this package lives in server_test.go; suite
+// registration below is package-global, so a second check.TestingT here would
+// run every suite twice.
+
+type PrefixSuite struct{}
+
+var _ = check.Suite(&PrefixSuite{})
+
+func (s *PrefixSuite) TestItemKey(c *check.C) {
+	c.Check(ItemKey("", "GIT_1_2_3.gob"), check.Equals, "GIT_1_2_3.gob")
+	c.Check(ItemKey("upsi", "abc"), check.Equals, "upsi/abc")
+	c.Check(ItemKey("a/b", "c"), check.Equals, "a/b/c")
+}
+
+func (s *PrefixSuite) TestKeyHasPrefix(c *check.C) {
+	c.Check(KeyHasPrefix("", "GIT_1_2_3.gob", "GIT_"), check.Equals, true)
+	c.Check(KeyHasPrefix("", "GIT_1_2_3.gob", ""), check.Equals, true)
+	c.Check(KeyHasPrefix("", "27_GIT_1_2_3.gob", "GIT_"), check.Equals, false)
+	c.Check(KeyHasPrefix("upsi", "abc", "GIT_"), check.Equals, false)
+	// A prefix need not fall on a path boundary.
+	c.Check(KeyHasPrefix("a", "bc", "a/b"), check.Equals, true)
+	c.Check(KeyHasPrefix("a", "c", "a/b"), check.Equals, false)
+}
+
+// TestSubtreeMayMatch is the pruning contract for a tree walk. Getting this
+// wrong in the false direction silently drops results, which is worse than the
+// full walk it replaces, so the boundary cases are enumerated explicitly.
+func (s *PrefixSuite) TestSubtreeMayMatch(c *check.C) {
+	// The root and the empty prefix always qualify.
+	c.Check(SubtreeMayMatch("", "GIT_"), check.Equals, true)
+	c.Check(SubtreeMayMatch("anything", ""), check.Equals, true)
+
+	// The prefix descends into this directory, so a match may lie deeper.
+	c.Check(SubtreeMayMatch("a", "a/b/c"), check.Equals, true)
+	c.Check(SubtreeMayMatch("a/b", "a/b/c"), check.Equals, true)
+
+	// The directory is itself inside the prefix, so everything below matches.
+	c.Check(SubtreeMayMatch("GIT_x", "GIT_"), check.Equals, true)
+	c.Check(SubtreeMayMatch("a", "a"), check.Equals, true)
+
+	// Unrelated subtrees are pruned. This is the case that makes a root-level
+	// prefix cheap: none of the cache's real subdirectories can match.
+	c.Check(SubtreeMayMatch("upsi", "GIT_"), check.Equals, false)
+	c.Check(SubtreeMayMatch("temp", "GIT_"), check.Equals, false)
+
+	// A sibling that merely shares a name prefix with the first path segment
+	// must NOT be descended: keys under "ab" are "ab/...", which can never begin
+	// with "a/b". Comparing against dir+"/" is what separates this from the
+	// "a/bc" case below.
+	c.Check(SubtreeMayMatch("ab", "a/b"), check.Equals, false)
+
+	// But a directory whose own name extends the prefix's last segment DOES
+	// qualify: keys under "a/bc" are "a/bc/...", which do begin with "a/b".
+	c.Check(SubtreeMayMatch("a/bc", "a/b"), check.Equals, true)
+}

--- a/pkg/rsstorage/server_metadata.go
+++ b/pkg/rsstorage/server_metadata.go
@@ -32,6 +32,25 @@ func NewMetadataStorageServer(args MetadataStorageServerArgs) StorageServer {
 	}
 }
 
+// EnumeratePrefix implements PrefixEnumerator by forwarding to the wrapped
+// server.
+//
+// This has to be written out. MetadataStorageServer embeds the StorageServer
+// INTERFACE, and embedding an interface promotes only the methods that interface
+// declares. EnumeratePrefix is not one of them, so without this method a
+// PrefixEnumerator type assertion against a wrapped server fails and the caller
+// silently loses prefix scoping -- on exactly the servers that are wrapped.
+//
+// Enumeration is a read that records no access time, so there is nothing to
+// account for here; contrast Get, which exists to do that bookkeeping.
+func (s *MetadataStorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
+	inner, ok := s.StorageServer.(PrefixEnumerator)
+	if !ok {
+		return nil, ErrPrefixEnumerationUnsupported
+	}
+	return inner.EnumeratePrefix(ctx, prefix)
+}
+
 func (s *MetadataStorageServer) Get(ctx context.Context, dir, address string) (io.ReadCloser, *types.ChunksInfo, int64, time.Time, bool, error) {
 	r, c, sz, ts, ok, err := s.StorageServer.Get(ctx, dir, address)
 	if ok && err == nil {

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/c2h5oh/datasize"
@@ -388,7 +389,7 @@ func (s *StorageServer) Remove(ctx context.Context, dir, address string) error {
 }
 
 func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
-	items, err := enumerate(s.dir, s.walkTimeout)
+	items, err := enumerate(ctx, s.dir, "", s.walkTimeout)
 	if err != nil {
 		slog.Error("Error enumerating storage", "error", err)
 
@@ -398,15 +399,46 @@ func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, erro
 	return internal.FilterChunks(items), nil
 }
 
-func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error) {
-	stop := make(chan struct{})
-	defer close(stop)
+// EnumeratePrefix implements rsstorage.PrefixEnumerator.
+//
+// The walk is pruned to the subtrees that can contain a matching key, so a
+// prefix that names no directory -- the common case of items stored flat at the
+// root -- reads only the root directory instead of descending the whole tree.
+func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
+	items, err := enumerate(ctx, s.dir, prefix, s.walkTimeout)
+	if err != nil {
+		slog.Error("Error enumerating storage", "error", err, "prefix", prefix)
 
-	itemChan := make(chan *types.StoredItem)
-	// errChan should have a buffer of two items to prevent deadlock between `<-stop` and `errChan<-err`
+		return nil, err
+	}
+
+	return internal.FilterChunks(items), nil
+}
+
+// enumerateChanBuffer batches items between the walker and its reader. The walk
+// is one channel send per file, and an unbuffered channel made that a scheduler
+// round trip each time; on a large store that dominated the walk itself.
+const enumerateChanBuffer = 256
+
+// enumerate walks dir and returns every file whose key is within prefix. An
+// empty prefix returns everything.
+//
+// walkTimeout bounds the gap BETWEEN items, not the total duration, so an
+// arbitrarily large store is fine as long as it keeps producing; a wedged
+// filesystem is not.
+func enumerate(ctx context.Context, dir, prefix string, walkTimeout time.Duration) ([]types.StoredItem, error) {
+	// Cancelled when this function returns, so an abandoned walker -- one whose
+	// reader gave up on timeout or error -- stops instead of blocking forever on
+	// a send that nobody will receive.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	itemChan := make(chan *types.StoredItem, enumerateChanBuffer)
+	// errChan should have a buffer of two items to prevent deadlock between the
+	// cancellation check and `errChan<-err`
 	errChan := make(chan error, 2)
 
-	go func(stop <-chan struct{}, itemChan chan<- *types.StoredItem, errChan chan<- error) {
+	go func(itemChan chan<- *types.StoredItem, errChan chan<- error) {
 		defer close(itemChan)
 		defer close(errChan)
 
@@ -416,21 +448,39 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 				return nil
 			}
 
-			if !info.IsDir() {
-				relPath, err := filepath.Rel(dir, path)
-				if err != nil {
-					return err
-				}
+			relPath, relErr := filepath.Rel(dir, path)
+			if relErr != nil {
+				return relErr
+			}
+			// filepath.Rel yields "." for the root itself.
+			if relPath == "." {
+				relPath = ""
+			}
+			key := filepath.ToSlash(relPath)
 
-				dir := filepath.Dir(relPath)
-				if dir == "." {
-					dir = ""
+			if info.IsDir() {
+				if !rsstorage.SubtreeMayMatch(key, prefix) {
+					return fs.SkipDir
 				}
+				return nil
+			}
 
-				itemChan <- &types.StoredItem{
-					Dir:     dir,
-					Address: info.Name(),
-				}
+			if !strings.HasPrefix(key, prefix) {
+				return nil
+			}
+
+			itemDir := filepath.Dir(relPath)
+			if itemDir == "." {
+				itemDir = ""
+			}
+
+			select {
+			case itemChan <- &types.StoredItem{
+				Dir:     itemDir,
+				Address: info.Name(),
+			}:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
 
 			return nil
@@ -439,7 +489,7 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 		if err != nil {
 			errChan <- err
 		}
-	}(stop, itemChan, errChan)
+	}(itemChan, errChan)
 
 	items := make([]types.StoredItem, 0)
 
@@ -452,19 +502,28 @@ func enumerate(dir string, walkTimeout time.Duration) ([]types.StoredItem, error
 
 	for {
 		select {
-		case item := <-itemChan:
+		case item, open := <-itemChan:
+			if !open {
+				// The walker is done and itemChan is drained. Only now is it safe
+				// to look at the error: itemChan is buffered, so selecting on
+				// errChan alongside it would let a completed walk return while
+				// items were still sitting in the buffer, silently dropping them.
+				// The walker sends its error before closing either channel, so
+				// this receive cannot block -- errChan is closed, or holds the
+				// error.
+				if err := <-errChan; err != nil {
+					return nil, err
+				}
+
+				return items, nil
+			}
+
 			if item != nil {
 				items = append(items, *item)
 			}
 
 			walkTimeoutTimer.Stop()
 			walkTimeoutTimer.Reset(walkTimeout)
-		case err := <-errChan:
-			if err != nil {
-				return nil, err
-			}
-
-			return items, nil
 		case <-walkTimeoutTimer.C:
 			return nil, walktimeoutErr
 		}

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -1062,10 +1062,24 @@ func (s *FileEnumerationSuite) TestEnumerateWalkTimeout(c *check.C) {
 // so when the reader gave up on the stall timeout the walker stayed blocked on a
 // send forever, holding its goroutine and directory handles. That leaked once per
 // timed-out listing, on exactly the oversized stores where the timeout fires.
+//
+// The tree must hold MORE than enumerateChanBuffer files. With fewer, the walker
+// drains into the buffer and exits on its own, so there is no blocked send to
+// leak and the test would pass whether or not the walker can be stopped. That is
+// what made an earlier version of this test vacuous.
 func (s *FileEnumerationSuite) TestEnumerateWalkTimeoutDoesNotLeakWalker(c *check.C) {
+	dir := s.tempDirHelper.Dir()
+	for i := range enumerateChanBuffer * 2 {
+		createTempFile(dir, fmt.Sprintf("file-%d", i), "hello world", c)
+	}
+
+	// leaktest snapshots goroutines when it is called, so it has to be armed
+	// after the fixture work above and before the call under test.
 	defer leaktest.Check(c)()
 
-	_, err := enumerate(context.Background(), "testdata", "", time.Nanosecond)
+	// A nanosecond stall timeout makes the reader give up immediately, while the
+	// walker is still blocked trying to hand over item 257.
+	_, err := enumerate(context.Background(), dir, "", time.Nanosecond)
 	c.Assert(err, check.Equals, walktimeoutErr)
 }
 

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -9,12 +9,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/fortytw2/leaktest"
 	"gopkg.in/check.v1"
 
 	"github.com/rstudio/platform-lib/v4/pkg/rsstorage"
@@ -904,6 +906,132 @@ func (s *FileEnumerationSuite) TestEnumerate(c *check.C) {
 	})
 }
 
+func (s *FileEnumerationSuite) TestEnumeratePrefix(c *check.C) {
+	ctx := context.Background()
+	server := &StorageServer{
+		dir:    s.tempDirHelper.Dir(),
+		fileIO: &defaultFileIO{},
+	}
+
+	createTempFile(server.dir, "GIT_1_2_3.gob", "legacy", c)
+	createTempFile(server.dir, "GIT_44_55_66.gob", "legacy", c)
+	createTempFile(server.dir, "27_GIT_1_2_3.gob", "current", c)
+	createTempFile(server.dir, "PACKAGES", "unrelated", c)
+	createTempFile(filepath.Join(server.dir, "upsi"), "GIT_9_9_9.gob", "nested, not root", c)
+	createTempFile(filepath.Join(server.dir, "GIT_dir"), "inner.gob", "inside the prefix", c)
+
+	// Root-level prefix: matches the two flat legacy keys, plus everything under
+	// a directory whose own name is within the prefix. It does NOT match the
+	// same-named file under upsi/, whose key is "upsi/GIT_9_9_9.gob".
+	en, err := server.EnumeratePrefix(ctx, "GIT_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, []types.StoredItem{
+		{Dir: "", Address: "GIT_1_2_3.gob"},
+		{Dir: "", Address: "GIT_44_55_66.gob"},
+		{Dir: "GIT_dir", Address: "inner.gob"},
+	})
+
+	// A prefix that descends into a directory.
+	en, err = server.EnumeratePrefix(ctx, "upsi/GIT_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, []types.StoredItem{
+		{Dir: "upsi", Address: "GIT_9_9_9.gob"},
+	})
+
+	// A prefix matching nothing yields an empty slice, not an error.
+	en, err = server.EnumeratePrefix(ctx, "NOPE_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.HasLen, 0)
+
+	// An empty prefix is equivalent to Enumerate.
+	en, err = server.EnumeratePrefix(ctx, "")
+	c.Assert(err, check.IsNil)
+	all, err := server.Enumerate(ctx)
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, all)
+}
+
+// TestEnumeratePrefixPrunesUnmatchedSubtrees asserts the performance property
+// rather than assuming it.
+//
+// Pruning is invisible in the returned items: a full walk that filtered by key
+// afterwards would produce byte-identical results, so no assertion on the item
+// list can distinguish the two. The tripwire is an unreadable directory. The
+// walker logs and swallows per-entry errors, so descending into one does not
+// change the result either -- but it does emit a log record. Enumerate walks in
+// and logs; EnumeratePrefix with a non-matching prefix must stay out and log
+// nothing.
+//
+// Without this, dropping the fs.SkipDir would restore the full walk with every
+// other test still green, which is exactly the silent regression this API exists
+// to prevent.
+func (s *FileEnumerationSuite) TestEnumeratePrefixPrunesUnmatchedSubtrees(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("running as root: mode 0000 does not deny access, so the tripwire cannot arm")
+	}
+
+	ctx := context.Background()
+	server := &StorageServer{
+		dir:    s.tempDirHelper.Dir(),
+		fileIO: &defaultFileIO{},
+	}
+
+	createTempFile(server.dir, "GIT_1_2_3.gob", "legacy", c)
+
+	// A subtree the walk must not enter. Unreadable, so entering it produces a
+	// log record we can detect.
+	unreadable := filepath.Join(server.dir, "unreadable")
+	createTempFile(unreadable, "buried.gob", "should never be visited", c)
+	c.Assert(os.Chmod(unreadable, 0o000), check.IsNil)
+	defer func() {
+		// Restore so the suite's TearDownTest can remove the tree.
+		c.Assert(os.Chmod(unreadable, 0o700), check.IsNil)
+	}()
+
+	// Enumerate walks into it and trips the wire.
+	walkLogs := countLogRecords(func() { _, _ = server.Enumerate(ctx) })
+	c.Check(walkLogs > 0, check.Equals, true,
+		check.Commentf("expected Enumerate to descend into the unreadable directory and log"))
+
+	// EnumeratePrefix prunes it and does not.
+	prefixLogs := countLogRecords(func() {
+		items, err := server.EnumeratePrefix(ctx, "GIT_")
+		c.Assert(err, check.IsNil)
+		c.Check(items, check.DeepEquals, []types.StoredItem{
+			{Dir: "", Address: "GIT_1_2_3.gob"},
+		})
+	})
+	c.Check(prefixLogs, check.Equals, 0,
+		check.Commentf("EnumeratePrefix descended into a subtree that cannot match the prefix"))
+}
+
+// countLogRecords runs fn with the default slog logger swapped for one that
+// counts records, and reports how many were emitted.
+func countLogRecords(fn func()) int {
+	counter := &countingHandler{}
+	restore := slog.Default()
+	slog.SetDefault(slog.New(counter))
+	defer slog.SetDefault(restore)
+
+	fn()
+	return counter.records
+}
+
+type countingHandler struct {
+	records int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *countingHandler) Handle(_ context.Context, _ slog.Record) error {
+	h.records++
+	return nil
+}
+
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *countingHandler) WithGroup(string) slog.Handler { return h }
+
 func (s *FileEnumerationSuite) TestEnumerateWalkTimeout(c *check.C) {
 	testFiles := 10
 	testStr := []byte("hello world")
@@ -924,7 +1052,20 @@ func (s *FileEnumerationSuite) TestEnumerateWalkTimeout(c *check.C) {
 		}(f.Name())
 	}
 
-	_, err := enumerate("testdata", time.Nanosecond)
+	_, err := enumerate(context.Background(), "testdata", "", time.Nanosecond)
+	c.Assert(err, check.Equals, walktimeoutErr)
+}
+
+// TestEnumerateWalkTimeoutDoesNotLeakWalker covers the abandoned-walker case.
+//
+// The walker used to be handed a `stop` channel that its body never selected on,
+// so when the reader gave up on the stall timeout the walker stayed blocked on a
+// send forever, holding its goroutine and directory handles. That leaked once per
+// timed-out listing, on exactly the oversized stores where the timeout fires.
+func (s *FileEnumerationSuite) TestEnumerateWalkTimeoutDoesNotLeakWalker(c *check.C) {
+	defer leaktest.Check(c)()
+
+	_, err := enumerate(context.Background(), "testdata", "", time.Nanosecond)
 	c.Assert(err, check.Equals, walktimeoutErr)
 }
 

--- a/pkg/rsstorage/servers/postgres/server.go
+++ b/pkg/rsstorage/servers/postgres/server.go
@@ -482,6 +482,58 @@ func (s *StorageServer) rem(ctx context.Context, location string) (err error) {
 	return
 }
 
+// EnumeratePrefix implements rsstorage.PrefixEnumerator.
+//
+// The prefix is pushed into the query rather than filtered in Go, so the scan is
+// bounded by the number of matching rows instead of every large object in the
+// database.
+func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) (items []types.StoredItem, err error) {
+	// Addresses are stored as "<class>/<key>", so anchor the pattern on both.
+	pattern := escapeLikePattern(s.class+"/"+prefix) + "%"
+	query := `SELECT address FROM large_objects WHERE address LIKE $1 ESCAPE '\' ORDER BY address`
+
+	items = make([]types.StoredItem, 0)
+	rows, err := s.pool.Query(ctx, query, pattern)
+	if errors.Is(err, sql.ErrNoRows) {
+		return items, nil
+	} else if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var address string
+		if err = rows.Scan(&address); err != nil {
+			return nil, err
+		}
+		key, ok := strings.CutPrefix(address, s.class+"/")
+		if !ok {
+			continue
+		}
+		dir := path.Dir(key)
+		if dir == "." {
+			dir = ""
+		}
+		items = append(items, types.StoredItem{
+			Dir:     dir,
+			Address: path.Base(key),
+		})
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return internal.FilterChunks(items), nil
+}
+
+// escapeLikePattern neutralizes the LIKE metacharacters in a literal prefix, so
+// that a key containing "_" or "%" matches only itself. Paired with
+// ESCAPE '\' in the query.
+func escapeLikePattern(literal string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(literal)
+}
+
 func (s *StorageServer) Enumerate(ctx context.Context) (items []types.StoredItem, err error) {
 	query := `SELECT address FROM large_objects ORDER BY address`
 	items = make([]types.StoredItem, 0)

--- a/pkg/rsstorage/servers/s3server/server.go
+++ b/pkg/rsstorage/servers/s3server/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -371,6 +372,60 @@ func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, erro
 		items = append(items, types.StoredItem{
 			Dir:     dir,
 			Address: filepath.Base(*path.Key),
+		})
+	}
+
+	return internal.FilterChunks(items), nil
+}
+
+// EnumeratePrefix implements rsstorage.PrefixEnumerator.
+//
+// The prefix is pushed down into ListObjectsV2, so S3 returns only matching keys
+// rather than the whole bucket.
+//
+// Unlike Enumerate, the returned Dir is relative to the server's configured
+// prefix, so an item can be handed straight back to Get, Check or Remove. Those
+// methods join s.prefix themselves, and Enumerate leaves it attached, which
+// makes its results non-round-trippable on a prefixed server. That asymmetry is
+// long-standing and callers may depend on it, so it is left alone here and only
+// the new API is correct by construction.
+func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
+	items := make([]types.StoredItem, 0)
+
+	listPrefix := prefix
+	if s.prefix != "" {
+		listPrefix = s.prefix + "/" + prefix
+	}
+
+	s3Objects, err := s.svc.ListObjects(ctx, &s3.ListObjectsV2Input{Bucket: &s.bucket, Prefix: &listPrefix})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, object := range s3Objects.Contents {
+		if object.Key == nil {
+			continue
+		}
+		key := *object.Key
+		if s.prefix != "" {
+			trimmed, ok := strings.CutPrefix(key, s.prefix+"/")
+			if !ok {
+				// Not under our prefix, so not ours to report. Cannot normally
+				// happen, since we asked S3 for this prefix.
+				continue
+			}
+			key = trimmed
+		}
+
+		// path, not filepath: these are S3 keys, always "/" separated, and
+		// filepath would use "\" on Windows.
+		dir := path.Dir(key)
+		if dir == "." {
+			dir = ""
+		}
+		items = append(items, types.StoredItem{
+			Dir:     dir,
+			Address: path.Base(key),
 		})
 	}
 

--- a/pkg/rsstorage/servers/s3server/server_test.go
+++ b/pkg/rsstorage/servers/s3server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +71,7 @@ type fakeS3 struct {
 	copyError    error
 	list         []string
 	listError    error
+	listPrefixes []string
 	bucketIn     *s3.CreateBucketInput
 	bucketOut    *s3.CreateBucketOutput
 	bucketErr    error
@@ -148,10 +150,26 @@ func (s *fakeS3) CopyObject(ctx context.Context, oldBucket, oldKey, newBucket, n
 	return nil, s.copyError
 }
 
+// ListObjects honors input.Prefix, the way S3 does.
+//
+// It deliberately filters rather than returning s.list wholesale: the whole
+// point of prefix enumeration is that the filter is pushed down to the service,
+// so a fake that ignored the prefix would let a caller that never sent one, or
+// sent the wrong one, pass anyway. listPrefixes records what was asked for so a
+// test can assert the pushdown happened at all.
 func (s *fakeS3) ListObjects(ctx context.Context, input *s3.ListObjectsV2Input) (*s3.ListObjectsV2Output, error) {
+	prefix := ""
+	if input.Prefix != nil {
+		prefix = *input.Prefix
+	}
+	s.listPrefixes = append(s.listPrefixes, prefix)
+
 	var contents []types.Object
 
 	for _, key := range s.list {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
 		contents = append(contents, types.Object{Key: &key})
 	}
 
@@ -607,6 +625,89 @@ func (s *S3StorageServerSuite) TestEnumerateError(c *check.C) {
 		svc: svc,
 	}
 	_, err := server.Enumerate(context.Background())
+	c.Assert(err, check.ErrorMatches, "list error")
+}
+
+// TestEnumeratePrefixPushesPrefixDown asserts the property the whole API exists
+// for: the filter reaches S3, so S3 returns only matching keys instead of the
+// caller receiving the bucket and discarding most of it.
+func (s *S3StorageServerSuite) TestEnumeratePrefixPushesPrefixDown(c *check.C) {
+	svc := &fakeS3{
+		list: []string{
+			"GIT_1_2_3.gob",
+			"GIT_44_55_66.gob",
+			"27_GIT_1_2_3.gob",
+			"upsi/GIT_9_9_9.gob",
+			"PACKAGES",
+		},
+	}
+	server := &StorageServer{svc: svc}
+
+	en, err := server.EnumeratePrefix(context.Background(), "GIT_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, []rtypes.StoredItem{
+		{Dir: "", Address: "GIT_1_2_3.gob"},
+		{Dir: "", Address: "GIT_44_55_66.gob"},
+	})
+
+	// The prefix was sent to S3 rather than applied after the fact.
+	c.Check(svc.listPrefixes, check.DeepEquals, []string{"GIT_"})
+}
+
+// TestEnumeratePrefixWithBucketPrefix covers the configured-prefix case, which is
+// where Enumerate is subtly wrong.
+//
+// Enumerate leaves the bucket prefix attached to Dir while Get, Check and Remove
+// all join it themselves, so its items are not round-trippable on a prefixed
+// server: passing one back addresses prefix/prefix/... and, because Remove
+// returns nil for a missing object, silently does nothing. EnumeratePrefix
+// strips it, so what comes out can go straight back in.
+func (s *S3StorageServerSuite) TestEnumeratePrefixWithBucketPrefix(c *check.C) {
+	svc := &fakeS3{
+		list: []string{
+			"myprefix/GIT_1_2_3.gob",
+			"myprefix/nested/GIT_7_8_9.gob",
+			"myprefix/PACKAGES",
+			// Another tenant sharing the bucket. Must never be returned.
+			"otherprefix/GIT_0_0_0.gob",
+		},
+	}
+	// Remove checks for the object first, so the round-trip assertion below needs
+	// a head response at the fully-joined key.
+	svc.headMap = map[string]HeadResponse{
+		"myprefix/nested/GIT_7_8_9.gob": {
+			head: &s3.HeadObjectOutput{
+				ContentLength: aws.Int64(12),
+				LastModified:  aws.Time(time.Now()),
+			},
+		},
+	}
+	server := &StorageServer{svc: svc, prefix: "myprefix"}
+
+	en, err := server.EnumeratePrefix(context.Background(), "GIT_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, []rtypes.StoredItem{
+		{Dir: "", Address: "GIT_1_2_3.gob"},
+	})
+
+	// The bucket prefix and the caller's prefix were combined for the service.
+	c.Check(svc.listPrefixes, check.DeepEquals, []string{"myprefix/GIT_"})
+
+	// Dir is relative to the server, so it round-trips through Remove.
+	en, err = server.EnumeratePrefix(context.Background(), "nested/GIT_")
+	c.Assert(err, check.IsNil)
+	c.Check(en, check.DeepEquals, []rtypes.StoredItem{
+		{Dir: "nested", Address: "GIT_7_8_9.gob"},
+	})
+
+	c.Assert(server.Remove(context.Background(), en[0].Dir, en[0].Address), check.IsNil)
+	c.Check(svc.deleted, check.Equals, "myprefix/nested/GIT_7_8_9.gob")
+}
+
+func (s *S3StorageServerSuite) TestEnumeratePrefixError(c *check.C) {
+	svc := &fakeS3{listError: errors.New("list error")}
+	server := &StorageServer{svc: svc}
+	_, err := server.EnumeratePrefix(context.Background(), "GIT_")
 	c.Assert(err, check.ErrorMatches, "list error")
 }
 

--- a/pkg/rsstorage/servertest.go
+++ b/pkg/rsstorage/servertest.go
@@ -23,27 +23,31 @@ type GetResult struct {
 }
 
 type DummyStorageServer struct {
-	GetAttempts    int
-	GetReader      io.ReadCloser
-	GetOk          bool
-	GetChunked     *types.ChunksInfo
-	GetSize        int64
-	GetModTime     time.Time
-	GetErr         error
-	GetMap         map[string]GetResult
-	RemoveErr      error
-	RemoveMap      map[string]bool
-	RemoveCount    int
-	Flushed        int
-	PutDelay       time.Duration
-	PutErr         error
-	PutCalled      int
-	PutChunks      bool
-	Address        []string
-	Placed         []string
-	Buffer         *bytes.Buffer
-	EnumItems      []types.StoredItem
-	EnumErr        error
+	GetAttempts int
+	GetReader   io.ReadCloser
+	GetOk       bool
+	GetChunked  *types.ChunksInfo
+	GetSize     int64
+	GetModTime  time.Time
+	GetErr      error
+	GetMap      map[string]GetResult
+	RemoveErr   error
+	RemoveMap   map[string]bool
+	RemoveCount int
+	Flushed     int
+	PutDelay    time.Duration
+	PutErr      error
+	PutCalled   int
+	PutChunks   bool
+	Address     []string
+	Placed      []string
+	Buffer      *bytes.Buffer
+	EnumItems   []types.StoredItem
+	EnumErr     error
+	// EnumPrefixes records every prefix EnumeratePrefix was called with, so a
+	// test can assert the caller scoped its listing rather than asking for
+	// everything.
+	EnumPrefixes   []string
 	MoveErr        error
 	Moved          []string
 	CopyErr        error
@@ -136,6 +140,24 @@ func (f *DummyStorageServer) Flush(ctx context.Context, dir, address string) {
 
 func (f *DummyStorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
 	return f.EnumItems, f.EnumErr
+}
+
+// EnumeratePrefix implements PrefixEnumerator against EnumItems.
+//
+// It really filters, rather than returning EnumItems wholesale, so that a test
+// asserting a caller only acts on matching keys cannot pass by accident.
+func (f *DummyStorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
+	f.EnumPrefixes = append(f.EnumPrefixes, prefix)
+	if f.EnumErr != nil {
+		return nil, f.EnumErr
+	}
+	items := make([]types.StoredItem, 0)
+	for _, item := range f.EnumItems {
+		if KeyHasPrefix(item.Dir, item.Address, prefix) {
+			items = append(items, item)
+		}
+	}
+	return items, nil
 }
 
 func (f *DummyStorageServer) Move(ctx context.Context, dir, address string, server StorageServer) error {


### PR DESCRIPTION
## Why

`Enumerate` lists an entire storage class, and it is the only listing primitive `rsstorage` has. A caller that wants a handful of known keys pays for the whole store.

That is not theoretical. In Posit Package Manager some customer cache directories are large enough that listing them is a real operational cost — enough that eviction has been turned off in places to avoid it. It also blocks PPM from cleaning up a specific set of legacy cache artifacts (rstudio/package-manager#19870, PR rstudio/package-manager#19924), because the only way to find them today is to enumerate everything, and the installations that most need that cleanup are precisely the ones that cannot afford the listing.

## What

`PrefixEnumerator`, an opt-in prefix-scoped listing.

It is a **separate interface, not a method on `StorageServer`** — deliberately. `StorageServer` has implementers outside this module, so extending it is a breaking change that would require a major version bump under the semver policy in `README.md`. Callers type-assert instead:

```go
if pe, ok := server.(rsstorage.PrefixEnumerator); ok {
    items, err := pe.EnumeratePrefix(ctx, "GIT_")
}
```

Every server in this module implements it, and there is a compile-time conformance assertion (`prefix_conformance_test.go`) to keep it that way — a type assertion fails *silently*, so a server that quietly stopped implementing it would degrade callers rather than break a build.

The prefix matches over the whole key (`Dir` and `Address` joined with `/`) and need not fall on a path boundary, which is what lets a caller ask for `GIT_` and get the flat keys at the root of a class.

### Per backend

| backend | how the prefix is applied |
|---|---|
| **file** | Prunes the walk with `fs.SkipDir`, so a prefix naming no directory reads only the root instead of descending the whole tree |
| **s3server** | Pushes the prefix into `ListObjectsV2`, so the service filters and returns only matching keys |
| **postgres** | Pushes the prefix into the query instead of selecting every large object and filtering in Go |

The filesystem pruning test, `SubtreeMayMatch`, is unit-tested at its boundaries, including the two cases that pull in opposite directions: `ab` must **not** be entered for prefix `a/b`, because its keys are `ab/...`; but `a/bc` **must** be, because its keys do begin with `a/b`.

For postgres, LIKE metacharacters in the prefix are escaped, so a key containing `_` matches only itself rather than any character.

### Returned items round-trip

On every backend, `Dir` is relative to the storage root, so an item can be handed straight back to `Get`, `Check` or `Remove`.

Worth calling out because `Enumerate` is subtly wrong here. On S3 it leaves the configured bucket prefix attached to `Dir` (`s3server/server.go:367`) while `Get`/`Check`/`Remove` join `s.prefix` themselves (`:352`, `:200`, `:509`). So its items are **not** round-trippable on a prefixed server: a `Remove` built from one addresses `prefix/prefix/...` and, because `Remove` returns nil for a missing object, silently does nothing while reporting success. That behaviour is long-standing and callers may depend on it, so I have left it alone and made only the new API correct by construction. Happy to fix `Enumerate` separately if you would rather — it looked like a change that deserves its own discussion rather than a drive-by.

## Two fixes to the existing walk, which this now shares

**A goroutine leak.** The walker was handed a `stop` channel that its body never selected on. When the reader gave up on the stall timeout, the walker stayed blocked on a send forever, holding its goroutine and its directory handles — leaking once per timed-out listing, on exactly the oversized stores where that timeout fires. It now stops on context cancellation.

**A buffered item channel**, which removes a scheduler round trip per file; on a large store that dominated the walk itself. That required reworking termination: the reader now drains the channel to closure before consulting the error, because selecting on both let a finished walk return while items were still sitting in the buffer. The pre-existing `TestEnumerate` caught that, via a chunked directory whose `info.json` went missing — the buffered items were being dropped.

`Enumerate` also now honours context cancellation, which it previously ignored entirely.

## Testing

- **Unit**: prefix matching and the pruning predicate at their boundaries; filesystem prefix scoping; S3 prefix pushdown, with and without a configured bucket prefix, including a round-trip through `Remove`; error paths.
- **Integration** (`just test-integration`, real Postgres + MinIO + filesystem): `StorageIntegrationSuite.TestEnumeratePrefix`. Two things are only testable there — the postgres SQL and its LIKE escaping never execute in a unit test, and `NewServerSet` wraps every backend in a `MetadataStorageServer`, so it also proves the decorator forwards the interface.
- The `fakeS3` double now **honors `input.Prefix`** and records what it was asked for. It previously ignored the prefix entirely, which would have made every prefix-pushdown assertion vacuous.

Each new test was mutation-tested — I broke the behaviour and confirmed the matching test fails:

| mutation | caught by |
|---|---|
| `return fs.SkipDir` → `return nil` | `TestEnumeratePrefixPrunesUnmatchedSubtrees` |
| remove ctx cancellation from the send | `TestEnumerateWalkTimeoutDoesNotLeakWalker` (leaked goroutine parked in `chan send`) |
| remove the decorator forwarding | `prefix_conformance_test.go`, at compile time |

One note on that middle row: the leak test was **vacuous when first written** and I only found out by mutating it. With the handful of files in `testdata` the walker drains into the 256-slot buffer and exits on its own, so there is no blocked send to leak. It now fills the tree past `enumerateChanBuffer` so the walker is genuinely still blocked when the reader abandons it.

`just lint`, `just vet` and the unit suites pass. The postgres and chunks suites fail locally without the compose environment (they need a real database) both before and after this change.

## Follow-up, not done here

Both backends still materialize every key into a slice, and S3 accumulates all pages before returning. A streaming or iterator variant would help `Enumerate` too, but it is a larger redesign of the call shape and this change does not need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
