### PR TITLE
fix(rsqueue): roll back a partially completed permit sweep

### DIFF
--- a/pkg/rsqueue/impls/database/tasks/monitor_test.go
+++ b/pkg/rsqueue/impls/database/tasks/monitor_test.go
@@ -46,6 +46,8 @@ type QueueTestStore struct {
 	permitsErr     error
 	permitsDeleted int
 	permitDelete   error
+	completeCalled int
+	completedWith  error
 	peek           []queue.QueueWork
 	peekErr        error
 }
@@ -54,7 +56,15 @@ func (s *QueueTestStore) BeginTransactionQueue(ctx context.Context, description 
 	return s, nil
 }
 
-func (s *QueueTestStore) CompleteTransaction(err *error) {}
+// CompleteTransaction records the error it was handed, which is what a real
+// implementation uses to decide between COMMIT and ROLLBACK. Tests assert on
+// completedWith to tell those two outcomes apart.
+func (s *QueueTestStore) CompleteTransaction(err *error) {
+	s.completeCalled++
+	if err != nil {
+		s.completedWith = *err
+	}
+}
 
 func (s *QueueTestStore) QueuePermits(ctx context.Context, name string) ([]queue.QueuePermit, error) {
 	s.permitsCalled++

--- a/pkg/rsqueue/impls/database/tasks/sweeper.go
+++ b/pkg/rsqueue/impls/database/tasks/sweeper.go
@@ -64,7 +64,13 @@ func (q *DatabaseQueueSweeperTask) Run(ctx context.Context) {
 	for _, permit := range permits {
 		if !q.monitor.Check(ctx, uint64(permit.PermitId()), permit.PermitCreated(), q.sweepFor) {
 			slog.Debug(fmt.Sprintf("Sweeping expired queue permit %d", permit.PermitId()))
-			err := tx.QueuePermitDelete(ctx, permit.PermitId())
+			// Assign to the outer `err`, do not redeclare it. The deferred
+			// CompleteTransaction above reads that variable to decide whether to commit
+			// or roll back, so a `:=` here would leave it nil and commit the permits
+			// deleted before the failure while abandoning the rest. That left the queue
+			// in a state no caller asked for: a partially swept set of permits, reported
+			// as a clean sweep.
+			err = tx.QueuePermitDelete(ctx, permit.PermitId())
 			if err != nil {
 				slog.Debug(fmt.Sprintf("Error removing expired queue permit with id %d: %s", permit.PermitId(), err))
 				return

--- a/pkg/rsqueue/impls/database/tasks/sweeper_test.go
+++ b/pkg/rsqueue/impls/database/tasks/sweeper_test.go
@@ -65,3 +65,59 @@ func (s *SweeperSuite) TestSweepErrs(c *check.C) {
 	q.Run(context.Background())
 	c.Assert(cstore.permitsCalled, check.Equals, 1)
 }
+
+// TestSweepOkCommits establishes the baseline for the test below: a sweep that
+// deletes every expired permit without error completes with a nil error, which is
+// what a real store commits on.
+func (s *SweeperSuite) TestSweepOkCommits(c *check.C) {
+	cstore := &QueueTestStore{
+		permits: []queue.QueuePermit{
+			&fakePermit{permitId: 23},
+			&fakePermit{permitId: 24},
+		},
+	}
+	q := &DatabaseQueueSweeperTask{
+		store:   cstore,
+		monitor: &fakeMonitor{},
+	}
+
+	q.Run(context.Background())
+	c.Assert(cstore.permitsDeleted, check.Equals, 2)
+	c.Assert(cstore.completeCalled, check.Equals, 1)
+	c.Assert(cstore.completedWith, check.IsNil)
+}
+
+// TestSweepDeleteErrRollsBack covers a failure part-way through the sweep.
+//
+// Run deletes each expired permit inside one transaction, and the deferred
+// CompleteTransaction decides between COMMIT and ROLLBACK by reading the `err`
+// variable. A `:=` on the delete inside the loop redeclared that variable, so a
+// mid-loop failure returned with the outer error still nil and the transaction
+// committed: the permits deleted before the failure were made permanent, the rest
+// were abandoned, and the caller was told the sweep succeeded.
+//
+// Asserting on completedWith rather than on the delete count is the point: the
+// buggy and fixed versions attempt exactly the same deletes and both return at the
+// first failure, so no count can tell them apart. The only observable difference is
+// the error the transaction is completed with, which is what decides whether the
+// partial result is kept.
+func (s *SweeperSuite) TestSweepDeleteErrRollsBack(c *check.C) {
+	deleteErr := errors.New("cannot delete permit")
+	cstore := &QueueTestStore{
+		permits: []queue.QueuePermit{
+			&fakePermit{permitId: 23},
+			&fakePermit{permitId: 24},
+		},
+		permitDelete: deleteErr,
+	}
+	q := &DatabaseQueueSweeperTask{
+		store:   cstore,
+		monitor: &fakeMonitor{},
+	}
+
+	q.Run(context.Background())
+
+	c.Assert(cstore.completeCalled, check.Equals, 1)
+	c.Assert(cstore.completedWith, check.Equals, deleteErr,
+		check.Commentf("a failed permit delete must roll the sweep back, not commit it"))
+}


### PR DESCRIPTION
## What

`DatabaseQueueSweeperTask.Run` could commit a partially completed permit sweep and report it to the caller as a clean one.

`Run` deletes every expired permit inside a single transaction, and the deferred `CompleteTransaction(&err)` reads the function's `err` variable to decide between COMMIT and ROLLBACK. The delete inside the loop was written with `:=`:

```go
err := tx.QueuePermitDelete(ctx, permit.PermitId())
```

which declares a **new** `err` scoped to the `if` body instead of assigning to the one the deferred call watches. So a failure part-way through the loop returned with the outer `err` still `nil`, and the transaction committed.

The observable result: the permits deleted before the failure were released and made permanent, the remainder were left held, and nothing recorded that the sweep had not finished. `Run` has no error return, so the only signal was a `slog.Debug` line.

## Fix

Assign to the outer `err`, so a failed delete rolls the whole sweep back. The sweep is idempotent and scheduled, so the next pass retries the same work — a rollback costs one interval, where the previous behaviour left the queue in a state no caller asked for.

## Tests

`TestSweepDeleteErrRollsBack` asserts on the error handed to `CompleteTransaction` rather than on a delete count. That distinction is the whole point: the buggy and fixed versions attempt exactly the same deletes and both return at the first failure, so no count can tell them apart. The only observable difference is whether the partial result is kept.

To make that assertable, `QueueTestStore.CompleteTransaction` now records the error it was given; it was previously an empty method, so no test could see commit-versus-rollback at all. The field is additive and no existing test reads it.

`TestSweepOkCommits` pins the successful case beside it, so the new assertion cannot pass for the wrong reason — without it, a fixture that never swept anything would satisfy a rollback assertion trivially.

Verified by reverting only `sweeper.go` and re-running: `TestSweepDeleteErrRollsBack` fails with `obtained = nil` against the expected delete error, and the other three cases still pass.

## Checks

- `go test ./pkg/rsqueue/...` — passes.
- `go build ./...` and `go vet ./...` — clean.
- `./scripts/fmt-check.sh`, `./scripts/header-check.sh`, `./scripts/test-wiring.sh` — pass.
- `go test ./...` — `pkg/rsnotify/listeners/postgrespgx` times out locally because it needs a reachable `postgres` host; that is the `just test-integration` path and is untouched by this change.

## Notes

I checked for the same shadowing elsewhere in the module. The only other `CompleteTransaction(&err)` user is `examples/cmd/markdownRenderer/store/queue.go`, which assigns rather than redeclares, and its `QueuePop` uses gorm's managed `db.Transaction(func(tx) error)`, which is correct by construction. This was the only instance.

Worth considering separately: `govet`'s `shadow` check is not enabled in `.golangci.yml`, and it catches this class directly. Enabling it would likely need a pass over existing findings, so it is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
