### PR TITLE
Honor context cancellation while enumerating file storage

### DIFF
--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -391,7 +391,11 @@ func (s *StorageServer) Remove(ctx context.Context, dir, address string) error {
 func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
 	items, err := enumerate(ctx, s.dir, "", s.walkTimeout)
 	if err != nil {
-		slog.Error("Error enumerating storage", "error", err)
+		if !errors.Is(err, context.Canceled) {
+			// A caller that cancelled got what it asked for; logging it at Error
+			// would report a fault every time a process shuts down mid-listing.
+			slog.Error("Error enumerating storage", "error", err)
+		}
 
 		return nil, err
 	}
@@ -407,7 +411,10 @@ func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, erro
 func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
 	items, err := enumerate(ctx, s.dir, prefix, s.walkTimeout)
 	if err != nil {
-		slog.Error("Error enumerating storage", "error", err, "prefix", prefix)
+		if !errors.Is(err, context.Canceled) {
+			// See Enumerate: a cancellation is the caller's own doing, not a fault.
+			slog.Error("Error enumerating storage", "error", err, "prefix", prefix)
+		}
 
 		return nil, err
 	}
@@ -443,6 +450,13 @@ func enumerate(ctx context.Context, dir, prefix string, walkTimeout time.Duratio
 		defer close(errChan)
 
 		err := filepath.WalkDir(dir, func(path string, info fs.DirEntry, err error) error {
+			// Checked here, not only on the send below. A cancelled walk that is
+			// traversing subtrees which produce no matching items never reaches a
+			// send, so without this it would run to completion regardless.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+
 			if err != nil {
 				slog.Error("Error enumerating storage for directory", "dir", dir, "error", err)
 				return nil
@@ -524,6 +538,14 @@ func enumerate(ctx context.Context, dir, prefix string, walkTimeout time.Duratio
 
 			walkTimeoutTimer.Stop()
 			walkTimeoutTimer.Reset(walkTimeout)
+		case <-ctx.Done():
+			// The walker's own cancellation check cannot cover this case. WalkDir
+			// calls the callback per directory entry, so a filesystem that has
+			// stopped answering ReadDir blocks INSIDE WalkDir and the callback
+			// never runs again. Without this the caller would then wait out
+			// walkTimeout -- five minutes by default -- after asking to stop.
+			// The walker is left to unblock on its own; nothing here can hurry it.
+			return nil, ctx.Err()
 		case <-walkTimeoutTimer.C:
 			return nil, walktimeoutErr
 		}

--- a/pkg/rsstorage/servers/file/server.go
+++ b/pkg/rsstorage/servers/file/server.go
@@ -391,9 +391,7 @@ func (s *StorageServer) Remove(ctx context.Context, dir, address string) error {
 func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, error) {
 	items, err := enumerate(ctx, s.dir, "", s.walkTimeout)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			// A caller that cancelled got what it asked for; logging it at Error
-			// would report a fault every time a process shuts down mid-listing.
+		if !isContextEnded(err) {
 			slog.Error("Error enumerating storage", "error", err)
 		}
 
@@ -411,8 +409,7 @@ func (s *StorageServer) Enumerate(ctx context.Context) ([]types.StoredItem, erro
 func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]types.StoredItem, error) {
 	items, err := enumerate(ctx, s.dir, prefix, s.walkTimeout)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			// See Enumerate: a cancellation is the caller's own doing, not a fault.
+		if !isContextEnded(err) {
 			slog.Error("Error enumerating storage", "error", err, "prefix", prefix)
 		}
 
@@ -426,6 +423,18 @@ func (s *StorageServer) EnumeratePrefix(ctx context.Context, prefix string) ([]t
 // is one channel send per file, and an unbuffered channel made that a scheduler
 // round trip each time; on a large store that dominated the walk itself.
 const enumerateChanBuffer = 256
+
+// isContextEnded reports whether err is the caller's context ending, in either
+// of its two forms.
+//
+// ⚠️ Both, not just context.Canceled. enumerate returns ctx.Err(), which is
+// DeadlineExceeded for a context.WithTimeout and Canceled for a
+// context.WithCancel, and a caller that set a deadline has asked for the stop
+// just as deliberately as one that called cancel(). Matching only Canceled would
+// keep logging a fault for every timed-out listing.
+func isContextEnded(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
 
 // enumerate walks dir and returns every file whose key is within prefix. An
 // empty prefix returns everything.

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -1128,6 +1128,53 @@ func (s *FileEnumerationSuite) TestEnumerateCancelledDoesNotReturnPartialResults
 	c.Check(items, check.IsNil)
 }
 
+// A context that ended is the caller's own doing in BOTH its forms, so neither is
+// logged as a storage fault.
+//
+// enumerate returns ctx.Err(), which is DeadlineExceeded for a deadline context
+// and Canceled for a cancel context. Guarding the log on Canceled alone left
+// every timed-out listing reporting a fault, which is the noise this suppression
+// exists to avoid.
+func (s *FileEnumerationSuite) TestEnumerateDoesNotLogAnEndedContextAsAFault(c *check.C) {
+	dir := s.tempDirHelper.Dir()
+	createTempFile(dir, "PACKAGES", "some data", c)
+	server := &StorageServer{dir: dir, fileIO: &defaultFileIO{}, walkTimeout: time.Minute}
+
+	deadlined, cancelDeadline := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelDeadline()
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, tc := range []struct {
+		ctx  context.Context
+		want error
+		desc string
+	}{
+		{ctx: deadlined, want: context.DeadlineExceeded, desc: "deadline"},
+		{ctx: cancelled, want: context.Canceled, desc: "cancel"},
+	} {
+		logs := countLogRecords(func() {
+			_, err := server.Enumerate(tc.ctx)
+			c.Check(err, check.Equals, tc.want, check.Commentf("%s", tc.desc))
+
+			_, err = server.EnumeratePrefix(tc.ctx, "PACK")
+			c.Check(err, check.Equals, tc.want, check.Commentf("%s", tc.desc))
+		})
+		c.Check(logs, check.Equals, 0, check.Commentf("%s: logged an ended context as a storage fault", tc.desc))
+	}
+
+	// A real failure is still logged. The walk timeout is not the caller's doing.
+	logs := countLogRecords(func() {
+		_, err := server.Enumerate(context.Background())
+		c.Check(err, check.IsNil)
+
+		server.walkTimeout = time.Nanosecond
+		_, err = server.Enumerate(context.Background())
+		c.Check(err, check.Equals, walktimeoutErr)
+	})
+	c.Check(logs, check.Equals, 1, check.Commentf("a walk timeout must still be reported"))
+}
+
 var _ = check.Suite(&FileCopyMoveSuite{})
 
 type FileCopyMoveSuite struct {

--- a/pkg/rsstorage/servers/file/server_test.go
+++ b/pkg/rsstorage/servers/file/server_test.go
@@ -1083,6 +1083,51 @@ func (s *FileEnumerationSuite) TestEnumerateWalkTimeoutDoesNotLeakWalker(c *chec
 	c.Assert(err, check.Equals, walktimeoutErr)
 }
 
+// A cancelled walk that produces no matching items must still report the
+// cancellation.
+//
+// This is the case the walker's send-side check cannot see: with a prefix that
+// matches nothing, there is never a send to select on, so the walk used to run to
+// completion and return an empty list and a NIL error. A caller that had already
+// given up was told the store was empty, and on a large tree it waited out the
+// whole walk to hear it.
+func (s *FileEnumerationSuite) TestEnumerateCancelledWithNoMatchesReportsCancellation(c *check.C) {
+	dir := s.tempDirHelper.Dir()
+	createTempFile(dir, "PACKAGES", "some data", c)
+	createTempFile(filepath.Join(dir, "af"), "data.json", "{}", c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// "nomatch" selects none of the files above, so no send is ever attempted.
+	items, err := enumerate(ctx, dir, "nomatch", time.Minute)
+	c.Assert(err, check.Equals, context.Canceled)
+	c.Check(items, check.IsNil)
+}
+
+// The same for a prefix that DOES match: cancellation wins over the items, so a
+// caller never gets a partial listing that reads as complete.
+//
+// Note this one passes on the pre-fix code too: with items to hand over, the
+// walker's send-side ctx.Done() check already aborted the walk. It is here to pin
+// that behaviour, not as coverage for the two checks added alongside it -- the
+// test above is the one that fails without them.
+func (s *FileEnumerationSuite) TestEnumerateCancelledDoesNotReturnPartialResults(c *check.C) {
+	dir := s.tempDirHelper.Dir()
+	for i := range enumerateChanBuffer * 2 {
+		createTempFile(dir, fmt.Sprintf("file-%d", i), "hello world", c)
+	}
+
+	defer leaktest.Check(c)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	items, err := enumerate(ctx, dir, "", time.Minute)
+	c.Assert(err, check.Equals, context.Canceled)
+	c.Check(items, check.IsNil)
+}
+
 var _ = check.Suite(&FileCopyMoveSuite{})
 
 type FileCopyMoveSuite struct {


### PR DESCRIPTION
## Description

`enumerate()` in the file storage server only checked its context on a channel send. A cancelled walk that was traversing subtrees producing no matching items therefore never reached a check: it ran the walk to completion and returned an empty list with a **nil error**, so a caller that had already given up was told the store held nothing. On a large tree it also waited out the whole walk to hear it.

The reader loop did not select on `ctx.Done()` at all, so a caller could sit for the full `walkTimeout` (five minutes by default) after asking to stop.

Two checks, and both are needed:

- `ctx.Err()` at the top of the `WalkDir` callback bounds the **work**: it stops the walker reading directories after the reader has returned. On the oversized stores where this matters, that wasted I/O is the reason to cancel in the first place.
- `case <-ctx.Done()` in the reader bounds the **wait**, and is the only one that can. `WalkDir` invokes the callback per directory entry, so a filesystem that has stopped answering `ReadDir` blocks *inside* `WalkDir` and the callback never runs again.

A cancellation is now a returned error, so `Enumerate` and `EnumeratePrefix` no longer log one at `Error`. A caller that cancelled got what it asked for, and reporting a fault every time a process shuts down mid-listing is a false operational signal.

Found by an unresolved RoboRev review on the `prefix-enumeration` branch; the finding survived to `main`.

## Testing

Two new cases in `FileEnumerationSuite`:

- `TestEnumerateCancelledWithNoMatchesReportsCancellation` is the regression test. A cancelled context and a prefix matching nothing means no send is ever attempted, which is exactly the case the old send-side check could not see. Neutering **both** new checks makes it fail with `obtained = nil` against `context canceled`, reproducing the original bug precisely.
- `TestEnumerateCancelledDoesNotReturnPartialResults` pins that cancellation wins over buffered items, so a caller never gets a partial listing that reads as complete. Its comment states plainly that it passes on the pre-fix code too, since the pre-existing send-side check already covered it; it is there to hold that behaviour, not as coverage for this change.

On coverage, stated rather than glossed: the callback check has no test of its own, and cannot easily have one. Once the context is cancelled the reader's `ctx.Done()` case is ready on the first pass through the select, so it decides the returned value regardless; the callback check only changes how much of the tree gets read. Isolating that would need either an injected walk counter or a timing assertion, and a deliberately timing-sensitive test is not worth it here. Both code comments say so at the point a reader would wonder.

`go test ./pkg/rsstorage/servers/file/` passes, including `leaktest` on both new cases.

`go test ./pkg/rsstorage/...` fails in `servers/postgres` and `internal/integration_test` on my host. Those are the Docker integration suites (`failed to connect to user=admin database=postgres: lookup postgres: no such host`) and I confirmed they fail identically with the change stashed, so they pre-date it.

## Risks

`Enumerate` and `EnumeratePrefix` can now return `context.Canceled` where they previously returned an empty list and nil. Callers that ignore the error and read the slice see the same empty slice as before. Callers that check the error now see the cancellation they caused, which is the point.
