### PR TITLE
Fix Unsubscribe deadlock during shutdown

### DIFF
--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -189,7 +189,12 @@ func (b *NotificationBroadcaster) Unsubscribe(ch <-chan listener.Notification) {
 		}
 	}
 	go drainer()
-	b.unsubscribe <- ch
+	select {
+	case b.unsubscribe <- ch:
+	case <-b.stopSignal:
+		// Broadcaster has stopped; all channels were closed by stop().
+		// The drainer will exit when it sees the closed channel.
+	}
 }
 
 // internal stop function that closes the destination channels.

--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -183,6 +183,9 @@ func (b *NotificationBroadcaster) SubscribeOne(dataType uint8, matcher Matcher) 
 // Unsubscribe removes a channel from receiving broadcast events. That channel is
 // closed as a consequence of unsubscribing.
 func (b *NotificationBroadcaster) Unsubscribe(ch <-chan listener.Notification) {
+	if ch == nil {
+		return
+	}
 	drainer := func() {
 		// It's possible that the broadcaster is still trying to send
 		// us events while we're attempting to unsubscribe. Create a

--- a/pkg/rsnotify/broadcaster/broadcaster.go
+++ b/pkg/rsnotify/broadcaster/broadcaster.go
@@ -142,15 +142,20 @@ type Subscription struct {
 }
 
 // Subscribe returns a new output channel that will receive all broadcast events.
+// Returns nil if the broadcaster has already stopped.
 func (b *NotificationBroadcaster) Subscribe(dataType uint8) <-chan listener.Notification {
 	c := make(chan listener.Notification)
 
-	b.subscribe <- Subscription{
+	select {
+	case b.subscribe <- Subscription{
 		C: c,
 		T: dataType,
+	}:
+		return c
+	case <-b.stopSignal:
+		// Broadcaster has stopped; return nil to indicate no subscription.
+		return nil
 	}
-
-	return c
 }
 
 // SubscribeOne returns a new output channel that will receive one and only one broadcast
@@ -158,16 +163,21 @@ func (b *NotificationBroadcaster) Subscribe(dataType uint8) <-chan listener.Noti
 // the event is passed over the output channel and the channel is immediately
 // unsubscribed. You should still call `Unsubscribe` with the channel in case an event
 // is never received.
+// Returns nil if the broadcaster has already stopped.
 func (b *NotificationBroadcaster) SubscribeOne(dataType uint8, matcher Matcher) <-chan listener.Notification {
 	c := make(chan listener.Notification)
 
-	b.subscribe <- Subscription{
+	select {
+	case b.subscribe <- Subscription{
 		C:   c,
 		T:   dataType,
 		One: matcher,
+	}:
+		return c
+	case <-b.stopSignal:
+		// Broadcaster has stopped; return nil to indicate no subscription.
+		return nil
 	}
-
-	return c
 }
 
 // Unsubscribe removes a channel from receiving broadcast events. That channel is

--- a/pkg/rsnotify/broadcaster/broadcaster_test.go
+++ b/pkg/rsnotify/broadcaster/broadcaster_test.go
@@ -257,7 +257,8 @@ func (s *BroadcasterSuite) TestUnsubscribeAfterStop(c *check.C) {
 }
 
 // TestSubscribeAfterStop verifies that Subscribe does not block when called
-// after the broadcaster has stopped, and returns nil.
+// after the broadcaster has stopped, returns nil, and that calling Unsubscribe
+// on the nil channel does not leak goroutines.
 func (s *BroadcasterSuite) TestSubscribeAfterStop(c *check.C) {
 	defer leaktest.Check(c)()
 
@@ -295,6 +296,9 @@ func (s *BroadcasterSuite) TestSubscribeAfterStop(c *check.C) {
 		c.Fatal("Subscribe blocked after broadcaster stopped")
 	}
 
+	// Unsubscribe(nil) should not block or leak goroutines
+	b.Unsubscribe(ch)
+
 	// Also test SubscribeOne
 	done2 := make(chan struct{})
 	var ch2 <-chan listener.Notification
@@ -309,4 +313,7 @@ func (s *BroadcasterSuite) TestSubscribeAfterStop(c *check.C) {
 	case <-time.After(time.Second):
 		c.Fatal("SubscribeOne blocked after broadcaster stopped")
 	}
+
+	// Unsubscribe(nil) should not block or leak goroutines
+	b.Unsubscribe(ch2)
 }

--- a/pkg/rsnotify/broadcaster/broadcaster_test.go
+++ b/pkg/rsnotify/broadcaster/broadcaster_test.go
@@ -5,6 +5,7 @@ package broadcaster
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/fortytw2/leaktest"
 	"gopkg.in/check.v1"
@@ -211,4 +212,46 @@ func (s *BroadcasterSuite) TestBroadcasterIP(c *check.C) {
 		ip: "10.16.17.18",
 	}
 	c.Assert(b.IP(), check.Equals, "10.16.17.18")
+}
+
+// TestUnsubscribeAfterStop verifies that Unsubscribe does not block when called
+// after the broadcaster has stopped. This was a bug where the send to the
+// unsubscribe channel would block forever if the broadcast loop had exited.
+func (s *BroadcasterSuite) TestUnsubscribeAfterStop(c *check.C) {
+	defer leaktest.Check(c)()
+
+	items := make(chan listener.Notification)
+	errs := make(chan error)
+	l := &FakeListener{
+		items: items,
+		errs:  errs,
+	}
+	stop := make(chan bool)
+	b, err := NewNotificationBroadcaster(l, stop)
+	c.Check(err, check.IsNil)
+
+	// Subscribe to get a channel
+	ch := b.Subscribe(1)
+
+	// Stop the broadcaster by signaling the stop channel
+	stop <- true
+
+	// Wait for the broadcaster to fully stop (stopSignal is closed on exit)
+	<-b.stopSignal
+
+	// Now call Unsubscribe after the broadcaster has stopped.
+	// This should NOT block - it should return immediately.
+	done := make(chan struct{})
+	go func() {
+		b.Unsubscribe(ch)
+		close(done)
+	}()
+
+	// If Unsubscribe blocks, this will timeout
+	select {
+	case <-done:
+		// Success - Unsubscribe returned
+	case <-time.After(time.Second):
+		c.Fatal("Unsubscribe blocked after broadcaster stopped")
+	}
 }

--- a/pkg/rsnotify/broadcaster/broadcaster_test.go
+++ b/pkg/rsnotify/broadcaster/broadcaster_test.go
@@ -255,3 +255,58 @@ func (s *BroadcasterSuite) TestUnsubscribeAfterStop(c *check.C) {
 		c.Fatal("Unsubscribe blocked after broadcaster stopped")
 	}
 }
+
+// TestSubscribeAfterStop verifies that Subscribe does not block when called
+// after the broadcaster has stopped, and returns nil.
+func (s *BroadcasterSuite) TestSubscribeAfterStop(c *check.C) {
+	defer leaktest.Check(c)()
+
+	items := make(chan listener.Notification)
+	errs := make(chan error)
+	l := &FakeListener{
+		items: items,
+		errs:  errs,
+	}
+	stop := make(chan bool)
+	b, err := NewNotificationBroadcaster(l, stop)
+	c.Check(err, check.IsNil)
+
+	// Stop the broadcaster by signaling the stop channel
+	stop <- true
+
+	// Wait for the broadcaster to fully stop (stopSignal is closed on exit)
+	<-b.stopSignal
+
+	// Now call Subscribe after the broadcaster has stopped.
+	// This should NOT block and should return nil.
+	done := make(chan struct{})
+	var ch <-chan listener.Notification
+	go func() {
+		ch = b.Subscribe(1)
+		close(done)
+	}()
+
+	// If Subscribe blocks, this will timeout
+	select {
+	case <-done:
+		// Success - Subscribe returned
+		c.Assert(ch, check.IsNil)
+	case <-time.After(time.Second):
+		c.Fatal("Subscribe blocked after broadcaster stopped")
+	}
+
+	// Also test SubscribeOne
+	done2 := make(chan struct{})
+	var ch2 <-chan listener.Notification
+	go func() {
+		ch2 = b.SubscribeOne(1, func(n listener.Notification) bool { return true })
+		close(done2)
+	}()
+
+	select {
+	case <-done2:
+		c.Assert(ch2, check.IsNil)
+	case <-time.After(time.Second):
+		c.Fatal("SubscribeOne blocked after broadcaster stopped")
+	}
+}

--- a/pkg/rsqueue/impls/database/queue.go
+++ b/pkg/rsqueue/impls/database/queue.go
@@ -197,16 +197,21 @@ func send(msg listener.Notification, ch chan listener.Notification, timeout time
 // the event is passed over the output channel and the channel is immediately
 // unsubscribed. You should still call `Unsubscribe` with the channel in case an event
 // is never received.
+// Returns nil if the queue's broadcaster has already stopped.
 func (q *DatabaseQueue) SubscribeOne(dataType uint8, matcher broadcaster.Matcher) <-chan listener.Notification {
 	c := make(chan listener.Notification)
 
-	q.subscribe <- broadcaster.Subscription{
+	select {
+	case q.subscribe <- broadcaster.Subscription{
 		C:   c,
 		T:   dataType,
 		One: matcher,
+	}:
+		return c
+	case <-q.stopChan:
+		// Queue broadcaster has stopped; return nil to indicate no subscription.
+		return nil
 	}
-
-	return c
 }
 
 // Unsubscribe removes a channel from receiving broadcast events. That channel is

--- a/pkg/rsqueue/impls/database/queue.go
+++ b/pkg/rsqueue/impls/database/queue.go
@@ -217,6 +217,9 @@ func (q *DatabaseQueue) SubscribeOne(dataType uint8, matcher broadcaster.Matcher
 // Unsubscribe removes a channel from receiving broadcast events. That channel is
 // closed as a consequence of unsubscribing.
 func (q *DatabaseQueue) Unsubscribe(ch <-chan listener.Notification) {
+	if ch == nil {
+		return
+	}
 	drainer := func() {
 		for {
 			_, more := <-ch

--- a/pkg/rsqueue/impls/database/queue.go
+++ b/pkg/rsqueue/impls/database/queue.go
@@ -35,6 +35,7 @@ type DatabaseQueue struct {
 	// Used by the queue's internal broadcaster
 	subscribe   chan broadcaster.Subscription
 	unsubscribe chan (<-chan listener.Notification)
+	stopChan    chan bool
 
 	// Define notifications to use
 	leaderChannel          string
@@ -82,6 +83,7 @@ func NewDatabaseQueue(cfg DatabaseQueueConfig) (queue.Queue, error) {
 
 		subscribe:   make(chan broadcaster.Subscription),
 		unsubscribe: make(chan (<-chan listener.Notification)),
+		stopChan:    cfg.StopChan,
 
 		wrapper: cfg.JobLifecycleWrapper,
 
@@ -219,7 +221,12 @@ func (q *DatabaseQueue) Unsubscribe(ch <-chan listener.Notification) {
 		}
 	}
 	go drainer()
-	q.unsubscribe <- ch
+	select {
+	case q.unsubscribe <- ch:
+	case <-q.stopChan:
+		// Queue broadcaster has stopped; all channels were closed by stop().
+		// The drainer will exit when it sees the closed channel.
+	}
 }
 
 // Stop the broadcaster safely.

--- a/pkg/rsqueue/impls/database/queue_test.go
+++ b/pkg/rsqueue/impls/database/queue_test.go
@@ -760,3 +760,56 @@ func (s *QueueSuite) TestUnsubscribeAfterStop(c *check.C) {
 		c.Fatal("Unsubscribe blocked after queue broadcaster stopped")
 	}
 }
+
+// TestSubscribeOneAfterStop verifies that SubscribeOne does not block when called
+// after the queue's internal broadcaster has stopped, and returns nil.
+func (s *QueueSuite) TestSubscribeOneAfterStop(c *check.C) {
+	defer leaktest.Check(c)()
+
+	msgs := make(chan listener.Notification)
+	stop := make(chan bool)
+	cf := &fakeCarrierFactory{}
+
+	qi, err := NewDatabaseQueue(DatabaseQueueConfig{
+		QueueName:              "test",
+		NotifyTypeWorkReady:    1,
+		NotifyTypeWorkComplete: 2,
+		NotifyTypeChunk:        3,
+		ChunkMatcher:           &fakeMatcher{},
+		CarrierFactory:         cf,
+		QueueStore:             s.store,
+		QueueMsgsChan:          msgs,
+		WorkMsgsChan:           msgs,
+		ChunkMsgsChan:          msgs,
+		StopChan:               stop,
+		JobLifecycleWrapper:    &fakeWrapper{},
+	})
+	c.Assert(err, check.IsNil)
+
+	// Type assert to get access to SubscribeOne method
+	q := qi.(*DatabaseQueue)
+
+	// Stop the queue's internal broadcaster by signaling the stop channel
+	stop <- true
+
+	// Wait for the broadcaster to fully stop (stop channel is closed on exit)
+	<-stop
+
+	// Now call SubscribeOne after the broadcaster has stopped.
+	// This should NOT block and should return nil.
+	done := make(chan struct{})
+	var ch <-chan listener.Notification
+	go func() {
+		ch = q.SubscribeOne(1, func(n listener.Notification) bool { return true })
+		close(done)
+	}()
+
+	// If SubscribeOne blocks, this will timeout
+	select {
+	case <-done:
+		// Success - SubscribeOne returned
+		c.Assert(ch, check.IsNil)
+	case <-time.After(time.Second):
+		c.Fatal("SubscribeOne blocked after queue broadcaster stopped")
+	}
+}

--- a/pkg/rsqueue/impls/database/queue_test.go
+++ b/pkg/rsqueue/impls/database/queue_test.go
@@ -762,7 +762,8 @@ func (s *QueueSuite) TestUnsubscribeAfterStop(c *check.C) {
 }
 
 // TestSubscribeOneAfterStop verifies that SubscribeOne does not block when called
-// after the queue's internal broadcaster has stopped, and returns nil.
+// after the queue's internal broadcaster has stopped, returns nil, and that
+// calling Unsubscribe on the nil channel does not leak goroutines.
 func (s *QueueSuite) TestSubscribeOneAfterStop(c *check.C) {
 	defer leaktest.Check(c)()
 
@@ -812,4 +813,7 @@ func (s *QueueSuite) TestSubscribeOneAfterStop(c *check.C) {
 	case <-time.After(time.Second):
 		c.Fatal("SubscribeOne blocked after queue broadcaster stopped")
 	}
+
+	// Unsubscribe(nil) should not block or leak goroutines
+	q.Unsubscribe(ch)
 }

--- a/pkg/rsqueue/impls/database/queue_test.go
+++ b/pkg/rsqueue/impls/database/queue_test.go
@@ -704,3 +704,59 @@ func (s *QueueSuite) TestHasAddressOk(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(has, check.Equals, true)
 }
+
+// TestUnsubscribeAfterStop verifies that Unsubscribe does not block when called
+// after the queue's internal broadcaster has stopped. This was a bug where the
+// send to the unsubscribe channel would block forever if the broadcast loop had
+// exited.
+func (s *QueueSuite) TestUnsubscribeAfterStop(c *check.C) {
+	defer leaktest.Check(c)()
+
+	msgs := make(chan listener.Notification)
+	stop := make(chan bool)
+	cf := &fakeCarrierFactory{}
+
+	qi, err := NewDatabaseQueue(DatabaseQueueConfig{
+		QueueName:              "test",
+		NotifyTypeWorkReady:    1,
+		NotifyTypeWorkComplete: 2,
+		NotifyTypeChunk:        3,
+		ChunkMatcher:           &fakeMatcher{},
+		CarrierFactory:         cf,
+		QueueStore:             s.store,
+		QueueMsgsChan:          msgs,
+		WorkMsgsChan:           msgs,
+		ChunkMsgsChan:          msgs,
+		StopChan:               stop,
+		JobLifecycleWrapper:    &fakeWrapper{},
+	})
+	c.Assert(err, check.IsNil)
+
+	// Type assert to get access to SubscribeOne/Unsubscribe methods
+	q := qi.(*DatabaseQueue)
+
+	// Subscribe to get a channel (using SubscribeOne with a matcher that accepts anything)
+	ch := q.SubscribeOne(1, func(n listener.Notification) bool { return true })
+
+	// Stop the queue's internal broadcaster by signaling the stop channel
+	stop <- true
+
+	// Wait for the broadcaster to fully stop (stop channel is closed on exit)
+	<-stop
+
+	// Now call Unsubscribe after the broadcaster has stopped.
+	// This should NOT block - it should return immediately.
+	done := make(chan struct{})
+	go func() {
+		q.Unsubscribe(ch)
+		close(done)
+	}()
+
+	// If Unsubscribe blocks, this will timeout
+	select {
+	case <-done:
+		// Success - Unsubscribe returned
+	case <-time.After(time.Second):
+		c.Fatal("Unsubscribe blocked after queue broadcaster stopped")
+	}
+}


### PR DESCRIPTION
### Description
The Unsubscribe methods in NotificationBroadcaster and DatabaseQueue blocked forever when called after the broadcaster's loop had exited.

During shutdown, if the broadcaster stops before a subscriber calls Unsubscribe, the send to the unsubscribe channel has no receiver and blocks forever, causing a goroutine leak.

Fix by using a select that also checks if the broadcaster has stopped (the stop channel is closed when the loop exits). When the broadcaster has already stopped, all channels were closed by stop(), so the drainer goroutine will exit naturally when it sees the closed channel.

Add unit tests that verify Unsubscribe returns immediately after the broadcaster has stopped.

Connected to: https://github.com/rstudio/package-manager/issues/19987