### PR TITLE
Make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.tag.outputs.tag }}
-        run: gh release create "$TAG" --generate-notes --verify-tag
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
+          else
+            gh release create "$TAG" --generate-notes --verify-tag
+          fi

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ without touching local git:
 gh workflow run release.yml -f version=v4.3.1
 ```
 
+Do not create the release manually via the GitHub UI — just create the tag and
+let the workflow handle the release.
+
 A major bump (e.g. v3 to v4) also requires updating the `/vN` suffix in the
 module path and all import paths, not just the tag.
 


### PR DESCRIPTION
### Description

Skip release creation if the release already exists. This prevents CI failures when a tag is created via GitHub UI while also manually creating the release.

Update README to clarify that releases should not be created manually.